### PR TITLE
Formatting suggestion

### DIFF
--- a/src/indice.Edi/EdiReader.cs
+++ b/src/indice.Edi/EdiReader.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi
 {
@@ -332,9 +333,9 @@ namespace indice.Edi
         /// <summary>
         /// Reads the next EDI token from the stream as a <see cref="Nullable{Decimal}"/>.
         /// </summary>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> is the format information needed to parse this into a float</param>
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> is the format information needed to parse this into a float</param>
         /// <returns>A <see cref="Nullable{Decimal}"/>. This method will return <c>null</c> at the end of an array.</returns>
-        public abstract decimal? ReadAsDecimal(Picture? picture);
+        public abstract decimal? ReadAsDecimal(IFormatSpec formatSpec);
 
         /// <summary>
         /// Reads the next EDI token from the stream as a <see cref="Nullable{DateTime}"/>.
@@ -348,7 +349,7 @@ namespace indice.Edi
             throw new NotImplementedException();
         }
         
-        internal decimal? ReadAsDecimalInternal(Picture? picture) {
+        internal decimal? ReadAsDecimalInternal(IFormatSpec formatSpec) {
             EdiToken t;
             if (!ReadInternal()) {
                 SetToken(EdiToken.None);
@@ -368,7 +369,7 @@ namespace indice.Edi
                     return null;
                 }
                 decimal d;
-                if (s.TryParse(picture, Grammar.DecimalMark, out d)) {
+                if (s.TryParse(formatSpec, Grammar.DecimalMark, out d)) {
                     SetToken(EdiToken.Float, d, false);
                     return d;
                 }

--- a/src/indice.Edi/EdiSerializer.cs
+++ b/src/indice.Edi/EdiSerializer.cs
@@ -233,7 +233,7 @@ namespace indice.Edi
             var dateString = cache.ContainsPath(valueInfo.Path) ? cache.ReadAsString(valueInfo.Path) :
                                                            read ? reader.ReadAsString() : (string)reader.Value;
             if (dateString != null) {
-                dateString = dateString.Substring(0, valueInfo.Picture.Scale);
+                dateString = dateString.Substring(0, valueInfo.FormatSpec.Scale);
                 var date = default(DateTime);
                 if (dateString.TryParseEdiDate(valueInfo.Format, CultureInfo.InvariantCulture, out date)) {
                     var existingDateObject = descriptor.Info.GetValue(structure.Instance);
@@ -258,8 +258,8 @@ namespace indice.Edi
         internal static void PopulateDecimalValue(EdiReader reader, EdiStructure structure, EdiPropertyDescriptor descriptor, bool read) {
             var cache = structure.CachedReads;
             var valueInfo = descriptor.ValueInfo;
-            var numberFloat = cache.ContainsPath(valueInfo.Path) ? cache.ReadAsDecimal(valueInfo.Path, descriptor.ValueInfo.Picture, reader.Grammar.DecimalMark) :
-                                                            read ? reader.ReadAsDecimal(descriptor.ValueInfo.Picture) : (decimal?)reader.Value;
+            var numberFloat = cache.ContainsPath(valueInfo.Path) ? cache.ReadAsDecimal(valueInfo.Path, descriptor.ValueInfo.FormatSpec, reader.Grammar.DecimalMark) :
+                                                            read ? reader.ReadAsDecimal(descriptor.ValueInfo.FormatSpec) : (decimal?)reader.Value;
             if (numberFloat != null) {
                 descriptor.Info.SetValue(structure.Instance, numberFloat);
             }
@@ -618,7 +618,7 @@ namespace indice.Edi
                         else if (path.ComponentIndex != property.PathInfo.ComponentIndex)
                             writer.WriteToken(EdiToken.ComponentStart);
                     }
-                    writer.WriteValue(value, property.ValueInfo.Picture, property.ValueInfo.Format);
+                    writer.WriteValue(value, property.ValueInfo.FormatSpec, property.ValueInfo.Format);
                 } else {
                     // this is somekind of structure. Group/Message/Segment/SegmentGroup/Element
                     // is it a collection of some kind?

--- a/src/indice.Edi/EdiTextReader.cs
+++ b/src/indice.Edi/EdiTextReader.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi
 {
@@ -51,8 +52,8 @@ namespace indice.Edi
         /// Reads the next EDI token from the stream as a <see cref="Nullable{Decimal}"/>.
         /// </summary>
         /// <returns>A <see cref="Nullable{Decimal}"/>. This method will return <c>null</c> at the end of an array.</returns>
-        public override decimal? ReadAsDecimal(Picture? picture = null) {
-            return ReadAsDecimalInternal(picture);
+        public override decimal? ReadAsDecimal(IFormatSpec formatSpec = null) {
+            return ReadAsDecimalInternal(formatSpec);
         }
 
         /// <summary>

--- a/src/indice.Edi/EdiTextWriter.cs
+++ b/src/indice.Edi/EdiTextWriter.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Text;
 using System.IO;
 using System.Xml;
+using indice.Edi.FormatSpec;
 using indice.Edi.Utilities;
 
 namespace indice.Edi
@@ -149,7 +150,7 @@ namespace indice.Edi
         /// Writes a <see cref="String"/> value.
         /// </summary>
         /// <param name="value">The <see cref="String"/> value to write.</param>
-        public override void WriteValue(string value, Picture? picture) {
+        public override void WriteValue(string value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.String);
             WriteEscapedString(value);
         }
@@ -224,9 +225,9 @@ namespace indice.Edi
         /// Writes a <see cref="Int32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int32"/> value to write.</param>
-        public override void WriteValue(int value, Picture? picture = null) {
+        public override void WriteValue(int value, IFormatSpec formatSpec = null) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -234,9 +235,9 @@ namespace indice.Edi
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        public override void WriteValue(uint value, Picture? picture = null) {
+        public override void WriteValue(uint value, IFormatSpec formatSpec = null) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -244,9 +245,9 @@ namespace indice.Edi
         /// Writes a <see cref="Int64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int64"/> value to write.</param>
-        public override void WriteValue(long value, Picture? picture = null) {
+        public override void WriteValue(long value, IFormatSpec formatSpec = null) {
             InternalWriteValue(EdiToken.Float);
-            _writer.Write(value.ToEdiString(picture));
+            _writer.Write(value.ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -254,9 +255,9 @@ namespace indice.Edi
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        public override void WriteValue(ulong value, Picture? picture = null) {
+        public override void WriteValue(ulong value, IFormatSpec formatSpec = null) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -264,21 +265,21 @@ namespace indice.Edi
         /// Writes a <see cref="Single"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Single"/> value to write.</param>
-        public override void WriteValue(float value, Picture? picture) {
+        public override void WriteValue(float value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Float);
-            _writer.Write(value.ToEdiString(picture, Grammar.DecimalMark));
+            _writer.Write(value.ToEdiString(formatSpec, Grammar.DecimalMark));
         }
 
         /// <summary>
         /// Writes a <see cref="Nullable{Single}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Single}"/> value to write.</param>
-        public override void WriteValue(float? value, Picture? picture = null) {
+        public override void WriteValue(float? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
                 InternalWriteValue(EdiToken.Float);
-                _writer.Write(value.ToEdiString(picture, Grammar.DecimalMark));
+                _writer.Write(value.ToEdiString(formatSpec, Grammar.DecimalMark));
             }
         }
 
@@ -286,21 +287,21 @@ namespace indice.Edi
         /// Writes a <see cref="Double"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Double"/> value to write.</param>
-        public override void WriteValue(double value, Picture? picture = null) {
+        public override void WriteValue(double value, IFormatSpec formatSpec = null) {
             InternalWriteValue(EdiToken.Float);
-            _writer.Write(value.ToEdiString(picture, Grammar.DecimalMark));
+            _writer.Write(value.ToEdiString(formatSpec, Grammar.DecimalMark));
         }
 
         /// <summary>
         /// Writes a <see cref="Nullable{Double}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Double}"/> value to write.</param>
-        public override void WriteValue(double? value, Picture? picture = null) {
+        public override void WriteValue(double? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
                 InternalWriteValue(EdiToken.Float);
-                _writer.Write(value.ToEdiString(picture, Grammar.DecimalMark));
+                _writer.Write(value.ToEdiString(formatSpec, Grammar.DecimalMark));
             }
         }
 
@@ -317,9 +318,9 @@ namespace indice.Edi
         /// Writes a <see cref="Int16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int16"/> value to write.</param>
-        public override void WriteValue(short value, Picture? picture) {
+        public override void WriteValue(short value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -327,9 +328,9 @@ namespace indice.Edi
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        public override void WriteValue(ushort value, Picture? picture) {
+        public override void WriteValue(ushort value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -347,9 +348,9 @@ namespace indice.Edi
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        public override void WriteValue(sbyte value, Picture? picture) {
+        public override void WriteValue(sbyte value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
-            _writer.Write(((int?)value).ToEdiString(picture));
+            _writer.Write(((int?)value).ToEdiString(formatSpec));
             //WriteIntegerValue(value, picture);
         }
 
@@ -357,9 +358,9 @@ namespace indice.Edi
         /// Writes a <see cref="Decimal"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Decimal"/> value to write.</param>
-        public override void WriteValue(decimal value, Picture? picture) {
+        public override void WriteValue(decimal value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Float);
-            _writer.Write(value.ToEdiString(picture, Grammar.DecimalMark));
+            _writer.Write(value.ToEdiString(formatSpec, Grammar.DecimalMark));
         }
 
         /// <summary>
@@ -428,7 +429,7 @@ namespace indice.Edi
             }
         }
 
-        private void WriteIntegerValue(long value, Picture? picture) {
+        private void WriteIntegerValue(long value, IFormatSpec formatSpec) {
             if (value >= 0 && value <= 9) {
                 _writer.Write((char)('0' + value));
             } else {
@@ -438,11 +439,11 @@ namespace indice.Edi
                     _writer.Write('-');
                 }
 
-                WriteIntegerValue(uvalue, picture);
+                WriteIntegerValue(uvalue, formatSpec);
             }
         }
 
-        private void WriteIntegerValue(ulong uvalue, Picture? picture) {
+        private void WriteIntegerValue(ulong uvalue, IFormatSpec formatSpec) {
             if (uvalue <= 9) {
                 _writer.Write((char)('0' + uvalue));
             } else {

--- a/src/indice.Edi/EdiWriter.cs
+++ b/src/indice.Edi/EdiWriter.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using indice.Edi.Utilities;
 using System.Globalization;
 using System.Linq;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi
 {
@@ -553,7 +554,7 @@ namespace indice.Edi
         /// Writes a <see cref="String"/> value.
         /// </summary>
         /// <param name="value">The <see cref="String"/> value to write.</param>
-        public virtual void WriteValue(string value, Picture? picture) {
+        public virtual void WriteValue(string value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.String);
         }
 
@@ -561,7 +562,7 @@ namespace indice.Edi
         /// Writes a <see cref="Int32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int32"/> value to write.</param>
-        public virtual void WriteValue(int value, Picture? picture) {
+        public virtual void WriteValue(int value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -569,7 +570,7 @@ namespace indice.Edi
         /// Writes a <see cref="UInt32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt32"/> value to write.</param>
-        public virtual void WriteValue(uint value, Picture? picture) {
+        public virtual void WriteValue(uint value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -577,7 +578,7 @@ namespace indice.Edi
         /// Writes a <see cref="Int64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int64"/> value to write.</param>
-        public virtual void WriteValue(long value, Picture? picture) {
+        public virtual void WriteValue(long value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -585,7 +586,7 @@ namespace indice.Edi
         /// Writes a <see cref="UInt64"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt64"/> value to write.</param>
-        public virtual void WriteValue(ulong value, Picture? picture) {
+        public virtual void WriteValue(ulong value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -593,7 +594,7 @@ namespace indice.Edi
         /// Writes a <see cref="Single"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Single"/> value to write.</param>
-        public virtual void WriteValue(float value, Picture? picture) {
+        public virtual void WriteValue(float value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Float);
         }
 
@@ -601,7 +602,7 @@ namespace indice.Edi
         /// Writes a <see cref="Double"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Double"/> value to write.</param>
-        public virtual void WriteValue(double value, Picture? picture) {
+        public virtual void WriteValue(double value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Float);
         }
 
@@ -617,7 +618,7 @@ namespace indice.Edi
         /// Writes a <see cref="Int16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int16"/> value to write.</param>
-        public virtual void WriteValue(short value, Picture? picture) {
+        public virtual void WriteValue(short value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -625,7 +626,7 @@ namespace indice.Edi
         /// Writes a <see cref="UInt16"/> value.
         /// </summary>
         /// <param name="value">The <see cref="UInt16"/> value to write.</param>
-        public virtual void WriteValue(ushort value, Picture? picture) {
+        public virtual void WriteValue(ushort value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -649,7 +650,7 @@ namespace indice.Edi
         /// Writes a <see cref="SByte"/> value.
         /// </summary>
         /// <param name="value">The <see cref="SByte"/> value to write.</param>
-        public virtual void WriteValue(sbyte value, Picture? picture) {
+        public virtual void WriteValue(sbyte value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Integer);
         }
 
@@ -657,7 +658,7 @@ namespace indice.Edi
         /// Writes a <see cref="Decimal"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Decimal"/> value to write.</param>
-        public virtual void WriteValue(decimal value, Picture? picture) {
+        public virtual void WriteValue(decimal value, IFormatSpec formatSpec) {
             InternalWriteValue(EdiToken.Float);
         }
 
@@ -697,11 +698,11 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Int32}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Int32}"/> value to write.</param>
-        public virtual void WriteValue(int? value, Picture? picture = null) {
+        public virtual void WriteValue(int? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -709,11 +710,11 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{UInt32}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt32}"/> value to write.</param>
-        public virtual void WriteValue(uint? value, Picture? picture = null) {
+        public virtual void WriteValue(uint? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -721,11 +722,11 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Int64}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Int64}"/> value to write.</param>
-        public virtual void WriteValue(long? value, Picture? picture = null) {
+        public virtual void WriteValue(long? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -733,11 +734,11 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{UInt64}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt64}"/> value to write.</param>
-        public virtual void WriteValue(ulong? value, Picture? picture = null) {
+        public virtual void WriteValue(ulong? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -745,11 +746,11 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Single}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Single}"/> value to write.</param>
-        public virtual void WriteValue(float? value, Picture? picture = null) {
+        public virtual void WriteValue(float? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -757,12 +758,12 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Double}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Double}"/> value to write.</param>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> picture that discribes the value.</param>
-        public virtual void WriteValue(double? value, Picture? picture = null) {
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> format spec that discribes the value.</param>
+        public virtual void WriteValue(double? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -782,12 +783,12 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Int16}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Int16}"/> value to write.</param>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> picture that discribes the value.</param>
-        public virtual void WriteValue(short? value, Picture? picture = null) {
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> format spec that discribes the value.</param>
+        public virtual void WriteValue(short? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -795,12 +796,12 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{UInt16}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{UInt16}"/> value to write.</param>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> picture that discribes the value.</param>
-        public virtual void WriteValue(ushort? value, Picture? picture = null) {
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> format spec that discribes the value.</param>
+        public virtual void WriteValue(ushort? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -832,12 +833,12 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{SByte}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{SByte}"/> value to write.</param>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> picture that discribes the value.</param>
-        public virtual void WriteValue(sbyte? value, Picture? picture = null) {
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> format spec that discribes the value.</param>
+        public virtual void WriteValue(sbyte? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -845,12 +846,12 @@ namespace indice.Edi
         /// Writes a <see cref="Nullable{Decimal}"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Nullable{Decimal}"/> value to write.</param>
-        /// <param name="picture">The <see cref="Nullable{Picture}"/> picture that discribes the value.</param>
-        public virtual void WriteValue(decimal? value, Picture? picture = null) {
+        /// <param name="formatSpec">The <see cref="Nullable{IFormatSpec}"/> format spec that discribes the value.</param>
+        public virtual void WriteValue(decimal? value, IFormatSpec formatSpec = null) {
             if (value == null) {
                 WriteNull();
             } else {
-                WriteValue(value.GetValueOrDefault(), picture);
+                WriteValue(value.GetValueOrDefault(), formatSpec);
             }
         }
 
@@ -928,9 +929,9 @@ namespace indice.Edi
         /// An error will raised if the value cannot be written as a single Edi token.
         /// </summary>
         /// <param name="value">The <see cref="Object"/> value to write.</param>
-        /// <param name="picture"></param>
+        /// <param name="formatSpec"></param>
         /// <param name="format">traditional string format mask</param>
-        public virtual void WriteValue(object value, Picture? picture, string format) {
+        public virtual void WriteValue(object value, IFormatSpec formatSpec, string format) {
             if (value == null) {
                 WriteNull();
             } else {
@@ -942,7 +943,7 @@ namespace indice.Edi
                 }
 #endif
 
-                WriteValue(this, ConvertUtils.GetTypeCode(value.GetType()), value, picture, format);
+                WriteValue(this, ConvertUtils.GetTypeCode(value.GetType()), value, formatSpec, format);
             }
         }
         #endregion
@@ -963,7 +964,7 @@ namespace indice.Edi
             }
         }
 
-        internal static void WriteValue(EdiWriter writer, PrimitiveTypeCode typeCode, object value, Picture? picture, string format) {
+        internal static void WriteValue(EdiWriter writer, PrimitiveTypeCode typeCode, object value, IFormatSpec formatSpec, string format) {
             switch (typeCode) {
                 case PrimitiveTypeCode.Char:
                     writer.WriteValue((char)value);
@@ -978,64 +979,64 @@ namespace indice.Edi
                     writer.WriteValue((value == null) ? (bool?)null : (bool)value);
                     break;
                 case PrimitiveTypeCode.SByte:
-                    writer.WriteValue((sbyte)value, picture);
+                    writer.WriteValue((sbyte)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.SByteNullable:
-                    writer.WriteValue((value == null) ? (sbyte?)null : (sbyte)value, picture);
+                    writer.WriteValue((value == null) ? (sbyte?)null : (sbyte)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Int16:
-                    writer.WriteValue((short)value, picture);
+                    writer.WriteValue((short)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Int16Nullable:
-                    writer.WriteValue((value == null) ? (short?)null : (short)value, picture);
+                    writer.WriteValue((value == null) ? (short?)null : (short)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt16:
-                    writer.WriteValue((ushort)value, picture);
+                    writer.WriteValue((ushort)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt16Nullable:
-                    writer.WriteValue((value == null) ? (ushort?)null : (ushort)value, picture);
+                    writer.WriteValue((value == null) ? (ushort?)null : (ushort)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Int32:
-                    writer.WriteValue((int)value, picture);
+                    writer.WriteValue((int)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Int32Nullable:
-                    writer.WriteValue((value == null) ? (int?)null : (int)value, picture);
+                    writer.WriteValue((value == null) ? (int?)null : (int)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Byte:
-                    writer.WriteValue((byte)value, picture);
+                    writer.WriteValue((byte)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.ByteNullable:
-                    writer.WriteValue((value == null) ? (byte?)null : (byte)value, picture);
+                    writer.WriteValue((value == null) ? (byte?)null : (byte)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt32:
-                    writer.WriteValue((uint)value, picture);
+                    writer.WriteValue((uint)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt32Nullable:
                     writer.WriteValue((value == null) ? (uint?)null : (uint)value);
                     break;
                 case PrimitiveTypeCode.Int64:
-                    writer.WriteValue((long)value, picture);
+                    writer.WriteValue((long)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Int64Nullable:
-                    writer.WriteValue((value == null) ? (long?)null : (long)value, picture);
+                    writer.WriteValue((value == null) ? (long?)null : (long)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt64:
-                    writer.WriteValue((ulong)value, picture);
+                    writer.WriteValue((ulong)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.UInt64Nullable:
-                    writer.WriteValue((value == null) ? (ulong?)null : (ulong)value, picture);
+                    writer.WriteValue((value == null) ? (ulong?)null : (ulong)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Single:
-                    writer.WriteValue((float)value, picture);
+                    writer.WriteValue((float)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.SingleNullable:
                     writer.WriteValue((value == null) ? (float?)null : (float)value);
                     break;
                 case PrimitiveTypeCode.Double:
-                    writer.WriteValue((double)value, picture);
+                    writer.WriteValue((double)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.DoubleNullable:
-                    writer.WriteValue((value == null) ? (double?)null : (double)value, picture);
+                    writer.WriteValue((value == null) ? (double?)null : (double)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.DateTime:
                     writer.WriteValue((DateTime)value, format);
@@ -1050,10 +1051,10 @@ namespace indice.Edi
                     writer.WriteValue((value == null) ? (DateTimeOffset?)null : (DateTimeOffset)value, format);
                     break;
                 case PrimitiveTypeCode.Decimal:
-                    writer.WriteValue((decimal)value, picture);
+                    writer.WriteValue((decimal)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.DecimalNullable:
-                    writer.WriteValue((value == null) ? (decimal?)null : (decimal)value, picture);
+                    writer.WriteValue((value == null) ? (decimal?)null : (decimal)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Guid:
                     writer.WriteValue((Guid)value);
@@ -1081,7 +1082,7 @@ namespace indice.Edi
                     writer.WriteValue((Uri)value);
                     break;
                 case PrimitiveTypeCode.String:
-                    writer.WriteValue((string)value, picture);
+                    writer.WriteValue((string)value, formatSpec);
                     break;
                 case PrimitiveTypeCode.Bytes:
                     writer.WriteValue((byte[])value);
@@ -1106,12 +1107,12 @@ namespace indice.Edi
 
                         object convertedValue = convertable.ToType(resolvedType, CultureInfo.InvariantCulture);
 
-                        WriteValue(writer, resolvedTypeCode, convertedValue, picture, format);
+                        WriteValue(writer, resolvedTypeCode, convertedValue, formatSpec, format);
                         break;
                     } else
 #endif
                     {
-                        WriteValue(writer, PrimitiveTypeCode.String, $"{value}", picture, format);
+                        WriteValue(writer, PrimitiveTypeCode.String, $"{value}", formatSpec, format);
                         break;
                         // consider throwing some times...
                         //throw CreateUnsupportedTypeException(writer, value);

--- a/src/indice.Edi/FormatSpec/EdifactSpec.cs
+++ b/src/indice.Edi/FormatSpec/EdifactSpec.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace indice.Edi.FormatSpec
+{
+    /// <summary>
+    /// String representation of the format of the element
+    /// 
+    /// a       alphabetic characters
+    /// n       numeric characters
+    /// an      alpha-numeric characters
+    /// a3      3 alphabetic characters, fixed length
+    /// n3      3 numeric characters, fixed length
+    /// an3     3 alpha-numeric characters, fixed length
+    /// a..3    up to 3 alphabetic characters, variable length
+    /// n..3    up to 3 numeric characters, variable length
+    /// an..3   up to 3 alpha-numeric characters, variable length
+    /// </summary>
+    public struct EdifactSpec : IFormatSpec
+    {
+        private const string PARSE_PATTERN = @"([a,n]{1,2})(\.\.)?(\d*)";
+        private readonly int? _scale;
+        private readonly FormatKind _kind;
+        private readonly bool _variableLength;
+        private readonly int _precision;
+
+        public EdifactSpec(FormatKind kind, bool variableLength, int? scale) {
+            _kind = kind;
+            _variableLength = variableLength;
+            _scale = scale;
+            _precision = 10;
+        }
+
+        /// <summary>
+        /// This is the total size of the string in digits
+        /// </summary>
+        public int Scale {
+            get { return _scale ?? int.MaxValue; }
+        }
+
+        /// <summary>
+        /// Length of field can is variable
+        /// </summary>
+        public bool VariableLength {
+            get { return _variableLength; }
+        }
+
+        /// <summary>
+        /// indicates the <see cref="Kind" /> of the value represented. (ie <see cref="EdifactSpecKind.Alphanumeric"/>)
+        /// </summary>
+        public FormatKind Kind {
+            get { return _kind; }
+        }
+
+        public int Precision {
+            get { return _precision; }
+        }
+
+        public bool IsValid {
+            get {
+                return _scale > 0;
+            }
+        }
+
+        public override int GetHashCode() {
+            return _kind.GetHashCode() ^ _scale.GetHashCode() ^ _variableLength.GetHashCode();
+        }
+
+        public override bool Equals(object obj) {
+            if (obj != null && obj is EdifactSpec) {
+                var other = ((EdifactSpec)obj);
+                return other._variableLength == _variableLength && other.Scale == Scale;
+            }
+            return base.Equals(obj);
+        }
+
+        public override string ToString()
+        {
+            string kindString;
+            switch (Kind)
+            {
+                case FormatKind.Alphanumeric:
+                    kindString = "an";
+                    break;
+                case FormatKind.Alphabetic:
+                    kindString = "a";
+                    break;
+                case FormatKind.Numeric:
+                    kindString = "n";
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            return $"{kindString}{(_variableLength ? ".." : "")}{(_scale.HasValue ? _scale.ToString() : "")}";
+        }
+
+        public static EdifactSpec Parse(string edifactSpecString) {
+            var match = Regex.Match(edifactSpecString, PARSE_PATTERN);
+
+            if (match == null || !match.Success || match.Groups.Count != 4) {
+                throw new ArgumentException($"'{edifactSpecString}' is not a valid Mig Spec string", nameof(edifactSpecString));
+            }
+
+            FormatKind kind;
+            switch (match.Groups[1].Value)
+            {
+                case "an":
+                    kind = FormatKind.Alphanumeric;
+                    break;
+                case "a":
+                    kind = FormatKind.Alphabetic;
+                    break;
+                case "n":
+                    kind = FormatKind.Numeric;
+                    break;
+                default:
+                    kind = FormatKind.Unknown;
+                    break;
+            }
+
+            var variableLength = match.Groups[2].Value == "..";
+            int? scale = null;
+            if (int.TryParse(match.Groups[3].Value, out int scaleTemp)) {
+                scale = scaleTemp;
+            }
+            return new EdifactSpec(kind, variableLength, scale);
+        }
+
+        public static implicit operator String(EdifactSpec value) {
+            return value.ToString();
+        }
+
+        public static explicit operator EdifactSpec(string value) {
+            return EdifactSpec.Parse(value);
+        }
+    }
+}

--- a/src/indice.Edi/FormatSpec/FormatKind.cs
+++ b/src/indice.Edi/FormatSpec/FormatKind.cs
@@ -1,0 +1,10 @@
+namespace indice.Edi.FormatSpec
+{
+    public enum FormatKind
+    {
+        Unknown = 0,
+        Alphanumeric = 1,
+        Alphabetic = 2,
+        Numeric = 3
+    }
+}

--- a/src/indice.Edi/FormatSpec/FormatSpecFactory.cs
+++ b/src/indice.Edi/FormatSpec/FormatSpecFactory.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace indice.Edi.FormatSpec
+{
+    public static class FormatSpecFactory
+    {
+        public static IFormatSpec Create(FormatterType formatterType, string spec)
+        {
+            switch (formatterType) {
+                case FormatterType.PictureSpec:
+                    return PictureSpec.Parse(spec);
+                    break;
+                case FormatterType.EdifactSpec:
+                    return EdifactSpec.Parse(spec);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(formatterType), formatterType, null);
+            }
+        }
+    }
+}

--- a/src/indice.Edi/FormatSpec/FormatterType.cs
+++ b/src/indice.Edi/FormatSpec/FormatterType.cs
@@ -1,0 +1,8 @@
+namespace indice.Edi.FormatSpec
+{
+    public enum FormatterType
+    {
+        PictureSpec,
+        EdifactSpec
+    }
+}

--- a/src/indice.Edi/FormatSpec/IFormatSpec.cs
+++ b/src/indice.Edi/FormatSpec/IFormatSpec.cs
@@ -1,0 +1,25 @@
+namespace indice.Edi.FormatSpec
+{
+    public interface IFormatSpec
+    {
+        /// <summary>
+        /// This is the total size of the string in digits
+        /// </summary>
+        int Scale { get; }
+
+        /// <summary>
+        /// Length of field can is variable
+        /// </summary>
+        bool VariableLength { get; }
+
+        /// <summary>
+        /// indicates the <see cref="Kind" /> of the value represented. (ie <see cref="FormatKind.Alphanumeric"/>)
+        /// </summary>
+        FormatKind Kind { get; }
+
+        /// <summary>
+        /// In case of floating point number this holds the number of decimal places. Its length.
+        /// </summary>
+        int Precision { get; }
+    }
+}

--- a/src/indice.Edi/FormatSpec/PictureSpec.cs
+++ b/src/indice.Edi/FormatSpec/PictureSpec.cs
@@ -1,29 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
-namespace indice.Edi
+namespace indice.Edi.FormatSpec
 {
-    public enum PictureKind
-    {
-        Alphanumeric,
-        Numeric
-    }
-
     /// <summary>
     /// Indicates the number of numeric (9) digits or alphanumeric (X) characters allowed in the data field.  
     /// If the field is numeric, this excludes any minus sign or the decimal point.  
     /// The decimal point is implied and its position within the data field is indicate by V.
     /// </summary>
-    public struct Picture
+    public struct PictureSpec : IFormatSpec
     {
         private const string PARSE_PATTERN = @"([9X]{1})\s?\((\d+?)\)\s?(V9\((\d+?)\))?";
         private readonly byte _Precision;
         private readonly byte _Scale;
-        private readonly PictureKind _Kind;
+        private readonly FormatKind _Kind;
 
         /// <summary>
         /// This is the total size of the string in digits
@@ -40,9 +30,9 @@ namespace indice.Edi
         }
 
         /// <summary>
-        /// indicates the <see cref="Kind" /> of the value represented. (ie <see cref="PictureKind.Alphanumeric"/>)
+        /// indicates the <see cref="Kind" /> of the value represented. (ie <see cref="FormatKind.Alphanumeric"/>)
         /// </summary>
-        public PictureKind Kind {
+        public FormatKind Kind {
             get { return _Kind; }
         }
 
@@ -61,25 +51,45 @@ namespace indice.Edi
             }
         }
 
-        public Picture(byte length) {
-            _Scale = length;
-            _Precision = 0;
-            _Kind = PictureKind.Alphanumeric;
+        public PictureSpec(string spec)
+        {
+            var match = Regex.Match(spec, PARSE_PATTERN);
+
+            if (match != null) {
+                var kind = match.Groups[1].Value == "X" ? FormatKind.Alphanumeric : FormatKind.Numeric;
+                var length = byte.Parse(match.Groups[2].Value);
+                byte decimalLength = 0;
+                if (kind == FormatKind.Numeric && !string.IsNullOrWhiteSpace(match.Groups[3].Value)) {
+                    decimalLength = byte.Parse(match.Groups[4].Value);
+                }
+                _Scale = (byte)(length + decimalLength);
+                _Precision = decimalLength;
+                _Kind = kind;
+
+            } else {
+                throw new ArgumentException($"Specification string '{spec}' could not be parsed to PictureSpec class", nameof(spec));
+            }
         }
 
-        public Picture(byte length, PictureKind kind) {
+        public PictureSpec(byte length) {
+            _Scale = length;
+            _Precision = 0;
+            _Kind = FormatKind.Alphanumeric;
+        }
+
+        public PictureSpec(byte length, FormatKind kind) {
             _Scale = length;
             _Precision = 0;
             _Kind = kind;
         }
 
-        public Picture(byte integerLength, byte decimalLength) {
+        public PictureSpec(byte integerLength, byte decimalLength) {
             _Scale = (byte)(integerLength + decimalLength);
             _Precision = decimalLength;
-            _Kind = PictureKind.Numeric;
+            _Kind = FormatKind.Numeric;
         }
 
-        public Picture(byte integerLength, byte decimalLength, PictureKind kind) {
+        public PictureSpec(byte integerLength, byte decimalLength, FormatKind kind) {
             _Scale = (byte)(integerLength + decimalLength);
             _Precision = decimalLength;
             _Kind = kind;
@@ -90,46 +100,38 @@ namespace indice.Edi
         }
 
         public override bool Equals(object obj) {
-            if (obj != null && obj is Picture) {
-                var other = ((Picture)obj);
+            if (obj != null && obj is PictureSpec) {
+                var other = ((PictureSpec)obj);
                 return other.Precision == Precision && other.Scale == Scale;
             }
             return base.Equals(obj);
         }
 
         public override string ToString() {
-            switch (Kind) {
-                case PictureKind.Alphanumeric:
+            switch (Kind)
+            {
+                case FormatKind.Alphanumeric:
                     return string.Format("X({0})", Scale);
-                case PictureKind.Numeric:
+                case FormatKind.Numeric:
                     return HasPrecision ? string.Format("9({0}) V9({1})", Scale - Precision, Precision) : string.Format("9({0})", Scale);
                 default:
-                    return string.Format("{0}({1},{2})", Kind, Scale, Precision);
+                    throw new ArgumentOutOfRangeException(nameof(Kind), $"Unsupported format kind: {Kind}");
             }
         }
 
-        public static Picture Parse(string text) {
-            var match = Regex.Match(text, PARSE_PATTERN);
-
-            if (match != null) {
-                var kind = match.Groups[1].Value == "X" ? PictureKind.Alphanumeric : PictureKind.Numeric;
-                var length = byte.Parse(match.Groups[2].Value);
-                byte decimalLength = 0;
-                if (kind == PictureKind.Numeric && !string.IsNullOrWhiteSpace(match.Groups[3].Value)) {
-                    decimalLength = byte.Parse(match.Groups[4].Value);
-                }
-                return new Picture(length, decimalLength, kind);
-            } else {
-                return new Picture();
-            }
+        public static PictureSpec Parse(string format)
+        {
+            return new PictureSpec(format);
         }
 
-        public static implicit operator String(Picture value) {
+        public static implicit operator String(PictureSpec value) {
             return value.ToString();
         }
 
-        public static explicit operator Picture(string value) {
-            return Picture.Parse(value);
+        public static explicit operator PictureSpec(string value) {
+            return PictureSpec.Parse(value);
         }
+
+        public bool VariableLength { get { return false; } }
     }
 }

--- a/src/indice.Edi/Serialization/EdiReadQueue.cs
+++ b/src/indice.Edi/Serialization/EdiReadQueue.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using indice.Edi.Utilities;
 using System.Globalization;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Serialization
 {
@@ -43,12 +44,12 @@ namespace indice.Edi.Serialization
             return integer;
         }
 
-        public static decimal? ReadAsDecimal(this Queue<EdiEntry> queue, string path, Picture? picture, char? decimalMark) {
+        public static decimal? ReadAsDecimal(this Queue<EdiEntry> queue, string path, IFormatSpec formatSpec, char? decimalMark) {
             var text = ReadAsString(queue, path);
             if (string.IsNullOrEmpty(text))
                 return null;
             
-            return text.Parse(picture, decimalMark);
+            return text.Parse(formatSpec, decimalMark);
         }
     }
 

--- a/src/indice.Edi/Serialization/EdiValueAttribute.cs
+++ b/src/indice.Edi/Serialization/EdiValueAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Serialization
 {
@@ -8,7 +9,7 @@ namespace indice.Edi.Serialization
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
     public sealed class EdiValueAttribute : EdiAttribute
     {
-        private Picture _picture;
+        private IFormatSpec _formatSpec;
         private bool _Mandatory;
         private string _Description;
         private string _Format;
@@ -34,21 +35,18 @@ namespace indice.Edi.Serialization
             set { _Path = value; }
         }
 
-        public Picture Picture {
-            get { return _picture; }
+        public IFormatSpec FormatSpec {
+            get { return _formatSpec; }
         }
 
-        public EdiValueAttribute()
-           : this(default(Picture)) {
+        public EdiValueAttribute() { 
+            _formatSpec = default(PictureSpec);
+
         }
 
-        public EdiValueAttribute(string picture)
-            : this((Picture)picture) {
+        public EdiValueAttribute(string spec, FormatterType formatterType)
+        {
+            _formatSpec = FormatSpecFactory.Create(formatterType, spec);
         }
-
-        public EdiValueAttribute(Picture picture) {
-            _picture = picture;
-        }
-        
     }
 }

--- a/test/indice.Edi.Tests/Models/EdiFact01.cs
+++ b/test/indice.Edi.Tests/Models/EdiFact01.cs
@@ -2,6 +2,7 @@
 using indice.Edi.Utilities;
 using System;
 using System.Collections.Generic;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Tests.Models.EdiFact01
 {
@@ -16,7 +17,7 @@ namespace indice.Edi.Tests.Models.EdiFact01
         }
 
         public static DTMPeriod Parse(string text) {
-            var textFrom  = text?.Substring(0, 12);
+            var textFrom = text?.Substring(0, 12);
             var textTo = text?.Substring(12, 12);
             return new DTMPeriod(
                     textFrom.ParseEdiDate("yyyyMMddHHmm"),
@@ -27,7 +28,7 @@ namespace indice.Edi.Tests.Models.EdiFact01
         public override string ToString() {
             return $"{From:yyyyMMddHHmm}{To:yyyyMMddHHmm}";
         }
-        
+
         public static implicit operator string(DTMPeriod value) {
             return value.ToString();
         }
@@ -42,26 +43,26 @@ namespace indice.Edi.Tests.Models.EdiFact01
     [EdiElement, EdiPath("DTM/0")]
     public class DTM
     {
-        [EdiValue("9(3)", Path = "DTM/0/0")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "DTM/0/0")]
         public int ID { get; set; }
-        [EdiValue("X(12)", Path = "DTM/0/1", Format = "yyyyMMddHHmm")]
+        [EdiValue("an..12", FormatterType.EdifactSpec, Path = "DTM/0/1", Format = "yyyyMMddHHmm")]
         public DateTime DateTime { get; set; }
-        [EdiValue("9(3)", Path = "DTM/0/2")]
+        [EdiValue("n3", FormatterType.EdifactSpec, Path = "DTM/0/2")]
         public int Code { get; set; }
 
         public override string ToString() {
             return DateTime.ToString();
         }
     }
-    
+
     [EdiElement, EdiPath("DTM/0"), EdiCondition("ZZZ", Path = "DTM/0/0")]
     public class UTCOffset
     {
-        [EdiValue("X(3)", Path = "DTM/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "DTM/0/0")]
         public int? ID { get; set; }
-        [EdiValue("9(1)", Path = "DTM/0/1")]
+        [EdiValue("n..1", FormatterType.EdifactSpec, Path = "DTM/0/1")]
         public int Hours { get; set; }
-        [EdiValue("9(3)", Path = "DTM/0/2")]
+        [EdiValue("n3", FormatterType.EdifactSpec, Path = "DTM/0/2")]
         public int Code { get; set; }
 
         public override string ToString() {
@@ -72,13 +73,13 @@ namespace indice.Edi.Tests.Models.EdiFact01
     [EdiElement, EdiPath("DTM/0"), EdiCondition("324", Path = "DTM/0/0")]
     public class Period
     {
-        [EdiValue("9(3)", Path = "DTM/0/0")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "DTM/0/0")]
         public int ID { get; set; }
 
-        [EdiValue("9(24)", Path = "DTM/0/1")]
+        [EdiValue("n..24", FormatterType.EdifactSpec, Path = "DTM/0/1")]
         public DTMPeriod Date { get; set; }
 
-        [EdiValue("9(3)", Path = "DTM/0/2")]
+        [EdiValue("n3", FormatterType.EdifactSpec, Path = "DTM/0/2")]
         public int Code { get; set; }
 
         public override string ToString() {
@@ -89,16 +90,16 @@ namespace indice.Edi.Tests.Models.EdiFact01
     [EdiElement, EdiPath("LIN/2")]
     public class ItemNumber
     {
-        [EdiValue("X(1)", Path = "LIN/2/0")]
+        [EdiValue("an..1", FormatterType.EdifactSpec, Path = "LIN/2/0")]
         public string Number { get; set; }
 
-        [EdiValue("9(3)", Path = "LIN/2/1")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "LIN/2/1")]
         public string Type { get; set; }
 
-        [EdiValue("9(3)", Path = "LIN/2/2")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "LIN/2/2")]
         public string CodeListQualifier { get; set; }
 
-        [EdiValue("9(3)", Path = "LIN/2/3")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "LIN/2/3")]
         public string CodeListResponsibleAgency { get; set; }
 
         public override string ToString() {
@@ -109,56 +110,56 @@ namespace indice.Edi.Tests.Models.EdiFact01
     [EdiSegment, EdiPath("NAD")]
     public class NAD
     {
-        [EdiValue("X(3)", Path = "NAD/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "NAD/0/0")]
         public string PartyQualifier { get; set; }
 
-        [EdiValue("X(35)", Path = "NAD/1/0")]
+        [EdiValue("an..35", FormatterType.EdifactSpec, Path = "NAD/1/0")]
         public string PartyId { get; set; }
 
-        [EdiValue("X(3)", Path = "NAD/1/2")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "NAD/1/2")]
         public string ResponsibleAgency { get; set; }
     }
 
 
     public class Interchange
     {
-        [EdiValue("X(4)", Mandatory = true, Path = "UNB/0")]
+        [EdiValue("an..4", FormatterType.EdifactSpec, Mandatory = true, Path = "UNB/0")]
         public string SyntaxIdentifier { get; set; }
 
-        [EdiValue("9(1)", Path = "UNB/0/1", Mandatory = true)]
+        [EdiValue("n..1", FormatterType.EdifactSpec, Path = "UNB/0/1", Mandatory = true)]
         public int SyntaxVersion { get; set; }
 
-        [EdiValue("X(35)", Path = "UNB/1/0", Mandatory = true)]
+        [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNB/1/0", Mandatory = true)]
         public string SenderId { get; set; }
-        [EdiValue("X(4)", Path = "UNB/1/1", Mandatory = true)]
+        [EdiValue("an..4", FormatterType.EdifactSpec, Path = "UNB/1/1", Mandatory = true)]
         public string PartnerIDCodeQualifier { get; set; }
-        [EdiValue("X(14)", Path = "UNB/1/2", Mandatory = false)]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/1/2", Mandatory = false)]
         public string ReverseRoutingAddress { get; set; }
 
-        [EdiValue("X(35)", Path = "UNB/2/0", Mandatory = true)]
+        [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNB/2/0", Mandatory = true)]
         public string RecipientId { get; set; }
 
-        [EdiValue("X(4)", Path = "UNB/2/1", Mandatory = true)]
+        [EdiValue("an..4", FormatterType.EdifactSpec, Path = "UNB/2/1", Mandatory = true)]
         public string ParterIDCode { get; set; }
-        [EdiValue("X(14)", Path = "UNB/2/2", Mandatory = false)]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/2/2", Mandatory = false)]
         public string RoutingAddress { get; set; }
 
-        [EdiValue("9(6)", Path = "UNB/3/0", Format = "ddMMyy", Description = "Date of Preparation")]
-        [EdiValue("9(4)", Path = "UNB/3/1", Format = "HHmm", Description = "Time or Prep")]
+        [EdiValue("n..6", FormatterType.EdifactSpec, Path = "UNB/3/0", Format = "ddMMyy", Description = "Date of Preparation")]
+        [EdiValue("n..4", FormatterType.EdifactSpec, Path = "UNB/3/1", Format = "HHmm", Description = "Time or Prep")]
         public DateTime DateOfPreparation { get; set; }
 
-        [EdiValue("X(14)", Path = "UNB/4", Mandatory = true)]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/4", Mandatory = true)]
         public string ControlRef { get; set; }
 
-        [EdiValue("9(1)", Path = "UNB/8", Mandatory = false)]
+        [EdiValue("n..1", FormatterType.EdifactSpec, Path = "UNB/8", Mandatory = false)]
         public int AckRequest { get; set; }
 
         public Quote QuoteMessage { get; set; }
 
-        [EdiValue("X(1)", Path = "UNZ/0")]
+        [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNZ/0")]
         public int TrailerControlCount { get; set; }
 
-        [EdiValue("X(14)", Path = "UNZ/1")]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNZ/1")]
         public string TrailerControlReference { get; set; }
     }
 
@@ -166,38 +167,38 @@ namespace indice.Edi.Tests.Models.EdiFact01
     public class Quote
     {
 
-        [EdiValue("X(14)", Path = "UNH/0/0")]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNH/0/0")]
         public string MessageRef { get; set; }
 
 
-        [EdiValue("X(6)", Path = "UNH/1/0")]
+        [EdiValue("an..6", FormatterType.EdifactSpec, Path = "UNH/1/0")]
         public string MessageType { get; set; }
 
-        [EdiValue("X(3)", Path = "UNH/1/1")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "UNH/1/1")]
         public string Version { get; set; }
 
-        [EdiValue("X(3)", Path = "UNH/1/2")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "UNH/1/2")]
         public string ReleaseNumber { get; set; }
 
-        [EdiValue("X(2)", Path = "UNH/1/3")]
+        [EdiValue("an..2", FormatterType.EdifactSpec, Path = "UNH/1/3")]
         public string ControllingAgency { get; set; }
 
-        [EdiValue("X(6)", Path = "UNH/1/4")]
+        [EdiValue("an..6", FormatterType.EdifactSpec, Path = "UNH/1/4")]
         public string AssociationAssignedCode { get; set; }
 
-        [EdiValue("X(35)", Path = "UNH/2/0")]
+        [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNH/2/0")]
         public string CommonAccessRef { get; set; }
 
-        [EdiValue("X(3)", Path = "BGM/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/0/0")]
         public string MessageName { get; set; }
 
-        [EdiValue("X(35)", Path = "BGM/1/0")]
+        [EdiValue("an..35", FormatterType.EdifactSpec, Path = "BGM/1/0")]
         public string DocumentNumber { get; set; }
 
-        [EdiValue("X(3)", Path = "BGM/2/0", Mandatory = false)]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/2/0", Mandatory = false)]
         public string MessageFunction { get; set; }
 
-        [EdiValue("X(3)", Path = "BGM/3/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/3/0")]
         public string ResponseType { get; set; }
 
         [EdiCondition("137", Path = "DTM/0/0")]
@@ -211,42 +212,42 @@ namespace indice.Edi.Tests.Models.EdiFact01
 
         public UTCOffset UTCOffset { get; set; }
 
-        [EdiValue("X(3)", Path = "CUX/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "CUX/0/0")]
         public string CurrencyQualifier { get; set; }
 
-        [EdiValue("X(3)", Path = "CUX/0/1")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "CUX/0/1")]
         public string ISOCurrency { get; set; }
 
         public List<NAD> NAD { get; set; }
 
-        [EdiValue("X(3)", Path = "LOC/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/0/0")]
         public string LocationQualifier { get; set; }
 
-        [EdiValue("X(3)", Path = "LOC/1/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/1/0")]
         public string LocationId { get; set; }
 
-        [EdiValue("X(3)", Path = "LOC/1/2")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/1/2")]
         public string LocationResponsibleAgency { get; set; }
 
         public List<LineItem> Lines { get; set; }
 
-        [EdiValue("X(1)", Path = "UNS/0/0")]
+        [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNS/0/0")]
         public char? UNS { get; set; }
 
-        [EdiValue("X(1)", Path = "UNT/0")]
+        [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNT/0")]
         public int TrailerMessageSegmentsCount { get; set; }
 
-        [EdiValue("X(14)", Path = "UNT/1")]
+        [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNT/1")]
         public string TrailerMessageReference { get; set; }
     }
 
     [EdiSegment, EdiSegmentGroup("LIN", SequenceEnd = "UNS")]
     public class LineItem
     {
-        [EdiValue("X(1)", Path = "LIN/0/0")]
+        [EdiValue("an..1", FormatterType.EdifactSpec, Path = "LIN/0/0")]
         public int LineNumber { get; set; }
 
-        [EdiValue("9(3)", Path = "LIN/1/0")]
+        [EdiValue("n..3", FormatterType.EdifactSpec, Path = "LIN/1/0")]
         public string Code { get; set; }
 
         public ItemNumber NumberIdentification { get; set; }
@@ -268,26 +269,26 @@ namespace indice.Edi.Tests.Models.EdiFact01
     [EdiElement, EdiPath("PRI/0")]
     public class Price
     {
-        [EdiValue("X(3)", Path = "PRI/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "PRI/0/0")]
         public string Code { get; set; }
 
-        [EdiValue("X(15)", Path = "PRI/0/1")]
+        [EdiValue("an..15", FormatterType.EdifactSpec, Path = "PRI/0/1")]
         public decimal? Amount { get; set; }
 
-        [EdiValue("X(3)", Path = "PRI/0/2")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "PRI/0/2")]
         public string Type { get; set; }
     }
 
     [EdiSegment, EdiPath("RNG")]
     public class Range
     {
-        [EdiValue("X(3)", Path = "RNG/0/0")]
+        [EdiValue("an..3", FormatterType.EdifactSpec, Path = "RNG/0/0")]
         public string MeasurementUnitCode { get; set; }
 
-        [EdiValue("X(18)", Path = "RNG/1/0")]
+        [EdiValue("an..18", FormatterType.EdifactSpec, Path = "RNG/1/0")]
         public decimal? Minimum { get; set; }
 
-        [EdiValue("X(18)", Path = "RNG/1/1")]
+        [EdiValue("an..18", FormatterType.EdifactSpec, Path = "RNG/1/1")]
         public decimal? Maximum { get; set; }
     }
 }

--- a/test/indice.Edi.Tests/Models/EdiFact01_Segments.cs
+++ b/test/indice.Edi.Tests/Models/EdiFact01_Segments.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using indice.Edi.FormatSpec;
 using indice.Edi.Serialization;
 using indice.Edi.Tests.Models.EdiFact01;
 
@@ -74,87 +75,86 @@ namespace indice.Edi.Tests.Models
         [EdiSegment, EdiPath("UNB")]
         public class UNB
         {
-            [EdiValue("X(4)", Mandatory = true, Path = "UNB/0")]
+            [EdiValue("an..4", FormatterType.EdifactSpec, Mandatory = true, Path = "UNB/0")]
             public string SyntaxIdentifier { get; set; }
 
-            [EdiValue("9(1)", Path = "UNB/0/1", Mandatory = true)]
+            [EdiValue("n..1", FormatterType.EdifactSpec, Path = "UNB/0/1", Mandatory = true)]
             public int SyntaxVersion { get; set; }
 
-            [EdiValue("X(35)", Path = "UNB/1/0", Mandatory = true)]
+            [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNB/1/0", Mandatory = true)]
             public string SenderId { get; set; }
-            [EdiValue("X(4)", Path = "UNB/1/1", Mandatory = true)]
+            [EdiValue("an..4", FormatterType.EdifactSpec, Path = "UNB/1/1", Mandatory = true)]
             public string PartnerIDCodeQualifier { get; set; }
-            [EdiValue("X(14)", Path = "UNB/1/2", Mandatory = false)]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/1/2", Mandatory = false)]
             public string ReverseRoutingAddress { get; set; }
 
-            [EdiValue("X(35)", Path = "UNB/2/0", Mandatory = true)]
+            [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNB/2/0", Mandatory = true)]
             public string RecipientId { get; set; }
 
-            [EdiValue("X(4)", Path = "UNB/2/1", Mandatory = true)]
+            [EdiValue("an..4", FormatterType.EdifactSpec, Path = "UNB/2/1", Mandatory = true)]
             public string ParterIDCode { get; set; }
-            [EdiValue("X(14)", Path = "UNB/2/2", Mandatory = false)]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/2/2", Mandatory = false)]
             public string RoutingAddress { get; set; }
 
-            [EdiValue("9(6)", Path = "UNB/3/0", Format = "ddMMyy", Description = "Date of Preparation")]
-            [EdiValue("9(4)", Path = "UNB/3/1", Format = "HHmm", Description = "Time or Prep")]
+            [EdiValue("n6", FormatterType.EdifactSpec, Path = "UNB/3/0", Format = "ddMMyy", Description = "Date of Preparation")]
+            [EdiValue("n4", FormatterType.EdifactSpec, Path = "UNB/3/1", Format = "HHmm", Description = "Time or Prep")]
             public DateTime DateOfPreparation { get; set; }
 
-            [EdiValue("X(14)", Path = "UNB/4", Mandatory = true)]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNB/4", Mandatory = true)]
             public string ControlRef { get; set; }
 
-            [EdiValue("9(1)", Path = "UNB/8", Mandatory = false)]
+            [EdiValue("n..1", FormatterType.EdifactSpec, Path = "UNB/8", Mandatory = false)]
             public int AckRequest { get; set; }
         }
 
         [EdiSegment, EdiPath("UNH")]
         public class UNH_Segment
         {
-            [EdiValue("X(14)", Path = "UNH/0/0")]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNH/0/0")]
             public string MessageRef { get; set; }
 
-
-            [EdiValue("X(6)", Path = "UNH/1/0")]
+            [EdiValue("an..6", FormatterType.EdifactSpec, Path = "UNH/1/0")]
             public string MessageType { get; set; }
 
-            [EdiValue("X(3)", Path = "UNH/1/1")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "UNH/1/1")]
             public string Version { get; set; }
 
-            [EdiValue("X(3)", Path = "UNH/1/2")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "UNH/1/2")]
             public string ReleaseNumber { get; set; }
 
-            [EdiValue("X(2)", Path = "UNH/1/3")]
+            [EdiValue("an..2", FormatterType.EdifactSpec, Path = "UNH/1/3")]
             public string ControllingAgency { get; set; }
 
-            [EdiValue("X(6)", Path = "UNH/1/4")]
+            [EdiValue("an..6", FormatterType.EdifactSpec, Path = "UNH/1/4")]
             public string AssociationAssignedCode { get; set; }
 
-            [EdiValue("X(35)", Path = "UNH/2/0")]
+            [EdiValue("an..35", FormatterType.EdifactSpec, Path = "UNH/2/0")]
             public string CommonAccessRef { get; set; }
         }
 
         [EdiSegment, EdiPath("UNZ")]
         public class UNZ
         {
-            [EdiValue("X(1)", Path = "UNZ/0")]
+            [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNZ/0")]
             public int TrailerControlCount { get; set; }
 
-            [EdiValue("X(14)", Path = "UNZ/1")]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNZ/1")]
             public string TrailerControlReference { get; set; }
         }
 
         [EdiSegment, EdiPath("BGM")]
         public class BGM_Segment
         {
-            [EdiValue("X(3)", Path = "BGM/0/0")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/0/0")]
             public string MessageName { get; set; }
 
-            [EdiValue("X(35)", Path = "BGM/1/0")]
+            [EdiValue("an..35", FormatterType.EdifactSpec, Path = "BGM/1/0")]
             public string DocumentNumber { get; set; }
 
-            [EdiValue("X(3)", Path = "BGM/2/0", Mandatory = false)]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/2/0", Mandatory = false)]
             public string MessageFunction { get; set; }
 
-            [EdiValue("X(3)", Path = "BGM/3/0")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "BGM/3/0")]
             public string ResponseType { get; set; }
         }
 
@@ -176,42 +176,42 @@ namespace indice.Edi.Tests.Models
         [EdiSegment, EdiPath("CUX")]
         public class CUX_Segment
         {
-            [EdiValue("X(3)", Path = "CUX/0/0")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "CUX/0/0")]
             public string CurrencyQualifier { get; set; }
 
-            [EdiValue("X(3)", Path = "CUX/0/1")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "CUX/0/1")]
             public string ISOCurrency { get; set; }
         }
 
         [EdiSegment, EdiPath("LOC")]
         public class LOC_Segment
         {
-            [EdiValue("X(3)", Path = "LOC/0/0")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/0/0")]
             public string LocationQualifier { get; set; }
 
-            [EdiValue("X(3)", Path = "LOC/1/0")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/1/0")]
             public string LocationId { get; set; }
 
-            [EdiValue("X(3)", Path = "LOC/1/2")]
+            [EdiValue("an..3", FormatterType.EdifactSpec, Path = "LOC/1/2")]
             public string LocationResponsibleAgency { get; set; }
         }
 
         [EdiSegment, EdiPath("UNS")]
         public class UNS_Segment
         {
-            [EdiValue("X(1)", Path = "UNS/0/0")]
+            [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNS/0/0")]
             public char? UNS { get; set; }
         }
 
         [EdiSegment, EdiPath("UNT")]
         public class UNT_Segment
         {
-            [EdiValue("X(1)", Path = "UNT/0")]
+            [EdiValue("an..1", FormatterType.EdifactSpec, Path = "UNT/0")]
             public int TrailerMessageSegmentsCount { get; set; }
 
-            [EdiValue("X(14)", Path = "UNT/1")]
+            [EdiValue("an..14", FormatterType.EdifactSpec, Path = "UNT/1")]
             public string TrailerMessageReference { get; set; }
         }
-        
+
     }
 }

--- a/test/indice.Edi.Tests/Models/ORDRSP.cs
+++ b/test/indice.Edi.Tests/Models/ORDRSP.cs
@@ -1,7 +1,7 @@
 ﻿#region Using
 
 using System.Collections.Generic;
-
+using indice.Edi.FormatSpec;
 using indice.Edi.Serialization;
 
 #endregion
@@ -36,7 +36,7 @@ namespace indice.Edi.Tests.Models
 
             #region Properties
 
-            [EdiValue("X(3)")]
+            [EdiValue("X(3)", FormatterType.PictureSpec)]
             [EdiPath("CTA/0/0")]
             public string Funktion
             {
@@ -44,7 +44,7 @@ namespace indice.Edi.Tests.Models
                 set { _funktion = value; }
             }
 
-            [EdiValue("X(17)")]
+            [EdiValue("X(17)", FormatterType.PictureSpec)]
             [EdiPath("CTA/1/0")]
             public string Kontaktnummer
             {
@@ -52,7 +52,7 @@ namespace indice.Edi.Tests.Models
                 set { _kontaktnummer = value; }
             }
 
-            [EdiValue("X(0)")]
+            [EdiValue("X(0)", FormatterType.PictureSpec)]
             [EdiPath("CTA/1/1")]
             public string Kontakt
             {
@@ -79,21 +79,21 @@ namespace indice.Edi.Tests.Models
 
             #region Properties
 
-            [EdiValue("X(3)", Path = "DTM/0/0")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "DTM/0/0")]
             public string Code
             {
                 get { return _code; }
                 set { _code = value; }
             }
 
-            [EdiValue("X(35)", Path = "DTM/0/1")]
+            [EdiValue("X(35)", FormatterType.PictureSpec, Path = "DTM/0/1")]
             public string Datum
             {
                 get { return _datum; }
                 set { _datum = value; }
             }
 
-            [EdiValue("X(3)", Path = "DTM/0/2")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "DTM/0/2")]
             public string Format
             {
                 get { return _format; }
@@ -151,21 +151,21 @@ namespace indice.Edi.Tests.Models
 
             #region Properties
 
-            [EdiValue("X(3)", Path = "NAD/0/0")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "NAD/0/0")]
             public string Qualifier
             {
                 get { return _qualifier; }
                 set { _qualifier = value; }
             }
 
-            [EdiValue("X(35)", Path="NAD/1/0")]
+            [EdiValue("X(35)", FormatterType.PictureSpec, Path="NAD/1/0")]
             public string ID
             {
                 get { return _id; }
                 set { _id = value; }
             }
 
-            [EdiValue("X(3)", Path= "NAD/1/2")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path= "NAD/1/2")]
             public string Code
             {
                 get { return _code; }
@@ -195,14 +195,14 @@ namespace indice.Edi.Tests.Models
 
             #region Properties
 
-            [EdiValue("X(70)", Path = "RFF/0/0")]
+            [EdiValue("X(70)", FormatterType.PictureSpec, Path = "RFF/0/0")]
             public string Code
             {
                 get { return _code; }
                 set { _code = value; }
             }
 
-            [EdiValue("X(3)", Path = "RFF/0/1")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "RFF/0/1")]
             public string Qualifier
             {
                 get { return _qualifier; }
@@ -227,13 +227,13 @@ namespace indice.Edi.Tests.Models
 
             #region Properties
 
-            [EdiValue("X(70)", Path = "RFF/0/0")]
+            [EdiValue("X(70)", FormatterType.PictureSpec, Path = "RFF/0/0")]
             public string Code {
                 get { return _code; }
                 set { _code = value; }
             }
 
-            [EdiValue("X(3)", Path = "RFF/0/1")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "RFF/0/1")]
             public string Qualifier {
                 get { return _qualifier; }
                 set { _qualifier = value; }

--- a/test/indice.Edi.Tests/Models/UtilityBill.cs
+++ b/test/indice.Edi.Tests/Models/UtilityBill.cs
@@ -3,19 +3,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Tests.Models
 {
     public class Interchange
     {
-        [EdiValue("X(14)", Path = "STX/1/0")]
+        [EdiValue("X(14)", FormatterType.PictureSpec, Path = "STX/1/0")]
         public string SenderCode { get; set; }
 
-        [EdiValue("X(35)", Path = "STX/1/1")]
+        [EdiValue("X(35)", FormatterType.PictureSpec, Path = "STX/1/1")]
         public string SenderName { get; set; }
 
-        [EdiValue("9(6)", Path = "STX/3/0", Format = "yyMMdd", Description = "TRDT - Date")]
-        [EdiValue("9(6)", Path = "STX/3/1", Format = "HHmmss", Description = "TRDT - Time")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "STX/3/0", Format = "yyMMdd", Description = "TRDT - Date")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "STX/3/1", Format = "HHmmss", Description = "TRDT - Time")]
         public DateTime TransmissionStamp { get; set; }
 
         public InterchangeHeader Head { get; set; }
@@ -31,13 +32,13 @@ namespace indice.Edi.Tests.Models
     [EdiMessage, EdiCondition("UTLHDR", Path = "MHD/1")]
     public class InterchangeHeader
     {
-        [EdiValue("9(4)"), EdiPath("TYP")]
+        [EdiValue("9(4)", FormatterType.PictureSpec), EdiPath("TYP")]
         public string TransactionCode { get; set; }
 
-        [EdiValue("9(1)", Path = "MHD/1/1")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MHD/1/1")]
         public int Version { get; set; }
 
-        [EdiValue("X(40)", Path = "CDT/1")]
+        [EdiValue("X(40)", FormatterType.PictureSpec, Path = "CDT/1")]
         public string ClientName { get; set; }
     }
 
@@ -45,17 +46,17 @@ namespace indice.Edi.Tests.Models
     public class InterchangeTrailer
     {
 
-        [EdiValue("9(1)", Path = "MHD/1/1")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MHD/1/1")]
         public int Version { get; set; }
     }
 
     [EdiMessage, EdiCondition("UVATLR", Path = "MHD/1")]
     public class InterchangeVatSummary
     {
-        [EdiValue("9(4)"), EdiPath("TYP")]
+        [EdiValue("9(4)", FormatterType.PictureSpec), EdiPath("TYP")]
         public string TransactionCode { get; set; }
 
-        [EdiValue("9(1)", Path = "MHD/1/1")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MHD/1/1")]
         public int Version { get; set; }
     }
 
@@ -64,25 +65,25 @@ namespace indice.Edi.Tests.Models
     [EdiMessage, EdiCondition("UTLBIL", Path = "MHD/1")]
     public class UtilityBill
     {
-        [EdiValue("9(1)", Path = "MHD/1/1")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MHD/1/1")]
         public int Version { get; set; }
 
-        [EdiValue("X(17)", Path = "BCD/2/0", Description = "INVN - Date")]
+        [EdiValue("X(17)", FormatterType.PictureSpec, Path = "BCD/2/0", Description = "INVN - Date")]
         public string InvoiceNumber { get; set; }
 
         public MetetAdminNumber Meter { get; set; }
         public ContractData SupplyContract { get; set; }
 
-        [EdiValue("X(3)", Path = "BCD/5/0", Description = "BTCD - Date")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "BCD/5/0", Description = "BTCD - Date")]
         public BillTypeCode BillTypeCode { get; set; }
 
-        [EdiValue("9(6)", Path = "BCD/1/0", Format = "yyMMdd", Description = "TXDT - Date")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "BCD/1/0", Format = "yyMMdd", Description = "TXDT - Date")]
         public DateTime IssueDate { get; set; }
 
-        [EdiValue("9(6)", Path = "BCD/7/0", Format = "yyMMdd", Description = "SUMO - Date")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "BCD/7/0", Format = "yyMMdd", Description = "SUMO - Date")]
         public DateTime StartDate { get; set; }
 
-        [EdiValue("9(6)", Path = "BCD/7/1", Format = "yyMMdd", Description = "SUMO - Date")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "BCD/7/1", Format = "yyMMdd", Description = "SUMO - Date")]
         public DateTime EndDate { get; set; }
 
         public UtilityBillTrailer Totals { get; set; }
@@ -98,76 +99,76 @@ namespace indice.Edi.Tests.Models
     public class ConsumptionChargeCharge
     {
         
-        [EdiValue("9(10)", Path = "CCD/0")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "CCD/0")]
         public int SequenceNumber { get; set; }
 
-        [EdiValue("X(3)", Path = "CCD/1")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "CCD/1")]
         public ChargeIndicator? ChargeIndicator { get; set; }
 
-        [EdiValue("9(13)", Path = "CCD/1/1")]
+        [EdiValue("9(13)", FormatterType.PictureSpec, Path = "CCD/1/1")]
         public int? ArticleNumber { get; set; }
 
-        [EdiValue("X(3)", Path = "CCD/1/2")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "CCD/1/2")]
         public string SupplierCode { get; set; }
 
 
-        [EdiValue("X(6)", Path = "CCD/2/0", Description = "TCOD")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/2/0", Description = "TCOD")]
         public string TariffCode { get; set; }
 
-        [EdiValue("X(40)", Path = "CCD/2/1", Description = "TCOD")]
+        [EdiValue("X(40)", FormatterType.PictureSpec, Path = "CCD/2/1", Description = "TCOD")]
         public string TariffDescription { get; set; }
 
 
-        [EdiValue("X(6)", Path = "CCD/3/0", Description = "TMOD")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/3/0", Description = "TMOD")]
         public string TariffCodeModifier1 { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/3/1", Description = "TMOD")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/3/1", Description = "TMOD")]
         public string TariffCodeModifier2 { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/3/2", Description = "TMOD")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/3/2", Description = "TMOD")]
         public string TariffCodeModifier3 { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/3/3", Description = "TMOD")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/3/3", Description = "TMOD")]
         public string TariffCodeModifier4 { get; set; }
 
 
-        [EdiValue("X(35)", Path = "CCD/4", Description = "MTNR")]
+        [EdiValue("X(35)", FormatterType.PictureSpec, Path = "CCD/4", Description = "MTNR")]
         public string MeterNumber { get; set; }
 
-        [EdiValue("X(40)", Path = "CCD/5", Description = "MLOC")]
+        [EdiValue("X(40)", FormatterType.PictureSpec, Path = "CCD/5", Description = "MLOC")]
         public string MeterLocation { get; set; }
 
-        [EdiValue("9(6)", Path = "CCD/6", Format = "yyMMdd", Description = "PRDT")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CCD/6", Format = "yyMMdd", Description = "PRDT")]
         public DateTime? PresentReadDate { get; set; }
 
-        [EdiValue("9(6)", Path = "CCD/7", Format = "yyMMdd", Description = "PVDT")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CCD/7", Format = "yyMMdd", Description = "PVDT")]
         public DateTime? PreviousReadDate { get; set; }
 
-        [EdiValue("9(3)", Path = "CCD/8", Description = "NDRP")]
+        [EdiValue("9(3)", FormatterType.PictureSpec, Path = "CCD/8", Description = "NDRP")]
         public int? ReadingPeriod { get; set; }
 
 
-        [EdiValue("9(15)", Path = "CCD/9/0", Description = "PRRD")]
+        [EdiValue("9(15)", FormatterType.PictureSpec, Path = "CCD/9/0", Description = "PRRD")]
         public decimal PresentReading { get; set; }
 
-        [EdiValue("X(4)", Path = "CCD/9/1", Description = "PRRD")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/9/1", Description = "PRRD")]
         public ReadingDataType? PresentReadingType { get; set; }
 
-        [EdiValue("9(15)", Path = "CCD/9/2", Description = "PRRD")]
+        [EdiValue("9(15)", FormatterType.PictureSpec, Path = "CCD/9/2", Description = "PRRD")]
         public decimal PreviousReading { get; set; }
 
-        [EdiValue("X(4)", Path = "CCD/9/3", Description = "PRRD")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/9/3", Description = "PRRD")]
         public ReadingDataType? PreviousReadingType { get; set; }
 
 
-        [EdiValue("9(10)V9(3)", Path = "CCD/10/0", Description = "CONS")]
+        [EdiValue("9(10)V9(3)", FormatterType.PictureSpec, Path = "CCD/10/0", Description = "CONS")]
         public decimal? UnitsConsumedBilling { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/10/1", Description = "CONS")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/10/1", Description = "CONS")]
         public string UnitOfMeasureBilling { get; set; }
         
         private string _UnitsNegativeBilling;
-        [EdiValue("X(4)", Path = "CCD/10/2", Description = "CONS")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/10/2", Description = "CONS")]
         public string UnitsNegativeBilling {
             get { return _UnitsNegativeBilling; }
             set {
@@ -179,14 +180,14 @@ namespace indice.Edi.Tests.Models
         }
 
 
-        [EdiValue("9(10)V9(3)", Path = "CCD/11/0", Description = "CONB")]
+        [EdiValue("9(10)V9(3)", FormatterType.PictureSpec, Path = "CCD/11/0", Description = "CONB")]
         public decimal? UnitsConsumedBase { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/11/1", Description = "CONB")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/11/1", Description = "CONB")]
         public string UnitOfMeasureBase { get; set; }
         
         private string _UnitsNegativeBase;
-        [EdiValue("X(4)", Path = "CCD/11/2", Description = "CONB")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/11/2", Description = "CONB")]
         public string UnitsNegativeBase {
             get { return _UnitsNegativeBase; }
             set {
@@ -198,70 +199,70 @@ namespace indice.Edi.Tests.Models
         }
 
 
-        [EdiValue("X(3)", Path = "CCD/12/0", Description = "ADJF")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "CCD/12/0", Description = "ADJF")]
         public string AdjustmentFactorCode { get; set; }
 
-        [EdiValue("9(10)V9(5)", Path = "CCD/12/1", Description = "ADJF")]
+        [EdiValue("9(10)V9(5)", FormatterType.PictureSpec, Path = "CCD/12/1", Description = "ADJF")]
         public decimal AdjustmentFactorValue { get; set; }
 
-        [EdiValue("X(4)", Path = "CCD/12/2", Description = "ADJF")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/12/2", Description = "ADJF")]
         public string AdjustmentFactorNegativeIndicator { get; set; }
 
 
-        [EdiValue("9(10)V9(3)", Path = "CCD/13/0", Description = "CONA")]
+        [EdiValue("9(10)V9(3)", FormatterType.PictureSpec, Path = "CCD/13/0", Description = "CONA")]
         public decimal UnitsConsumedAdjusted { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/13/1", Description = "CONA")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/13/1", Description = "CONA")]
         public string UnitOfMeasureAdjusted { get; set; }
         
-        [EdiValue("X(4)", Path = "CCD/13/2", Description = "CONA")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/13/2", Description = "CONA")]
         public string NegativeIndicatorAdjusted { get; set; }
 
 
-        [EdiValue("9(10)V9(5)", Path = "CCD/14", Description = "BPRI")]
+        [EdiValue("9(10)V9(5)", FormatterType.PictureSpec, Path = "CCD/14", Description = "BPRI")]
         public decimal? BasePriceUnit { get; set; }
 
 
-        [EdiValue("9(10)V9(3)", Path = "CCD/15/0", Description = "NUCT")]
+        [EdiValue("9(10)V9(3)", FormatterType.PictureSpec, Path = "CCD/15/0", Description = "NUCT")]
         public decimal UnitsBilled { get; set; }
 
-        [EdiValue("X(6)", Path = "CCD/15/1", Description = "NUCT")]
+        [EdiValue("X(6)", FormatterType.PictureSpec, Path = "CCD/15/1", Description = "NUCT")]
         public string UnitOfMeasureBilled { get; set; }
        
-        [EdiValue("X(4)", Path = "CCD/15/2", Description = "NUCT")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/15/2", Description = "NUCT")]
         public string NegativeIndicatorBilled { get; set; }
 
 
-        [EdiValue("9(6)", Path = "CCD/16", Format = "yyMMdd", Description = "CSDT")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CCD/16", Format = "yyMMdd", Description = "CSDT")]
         public DateTime ChargeStartDate { get; set; }
 
-        [EdiValue("9(6)", Path = "CCD/17", Format = "yyMMdd", Description = "CEDT")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CCD/17", Format = "yyMMdd", Description = "CEDT")]
         public DateTime ChargeEndDate { get; set; }
 
-        [EdiValue("9(10)V9(5)", Path = "CCD/18", Description = "CPPU")]
+        [EdiValue("9(10)V9(5)", FormatterType.PictureSpec, Path = "CCD/18", Description = "CPPU")]
         public decimal? PricePerUnit { get; set; }
 
 
-        [EdiValue("9(10)V9(2)", Path = "CCD/18/0", Description = "CTOT")]
+        [EdiValue("9(10)V9(2)", FormatterType.PictureSpec, Path = "CCD/18/0", Description = "CTOT")]
         public decimal TotalChargeForChargeType { get; set; }
 
-        [EdiValue("X(4)", Path = "CCD/18/1", Description = "CTOT")]
+        [EdiValue("X(4)", FormatterType.PictureSpec, Path = "CCD/18/1", Description = "CTOT")]
         public string TotalChargeCreditIndicator { get; set; }
 
 
-        [EdiValue("X(1)", Path = "CCD/19", Description = "TSUP")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "CCD/19", Description = "TSUP")]
         public string VatTypeOfSupply { get; set; }
 
-        [EdiValue("X(1)", Path = "CCD/20", Description = "VATC")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "CCD/20", Description = "VATC")]
         public VatRateCategoryCode? VatRateCategoryCode { get; set; }
 
-        [EdiValue("9(3)V9(3)", Path = "CCD/21", Description = "VATP")]
+        [EdiValue("9(3)V9(3)", FormatterType.PictureSpec, Path = "CCD/21", Description = "VATP")]
         public string VatRatePercentage { get; set; }
 
-        [EdiValue("X(17)", Path = "CCD/22/0", Description = "MSAD")]
+        [EdiValue("X(17)", FormatterType.PictureSpec, Path = "CCD/22/0", Description = "MSAD")]
         public string MeterSubAddressCode { get; set; }
 
-        [EdiValue("X(40)", Path = "CCD/22/1", Description = "MSAD")]
+        [EdiValue("X(40)", FormatterType.PictureSpec, Path = "CCD/22/1", Description = "MSAD")]
         public string MeterSubAddressLine { get; set; }
 
         public override string ToString() {
@@ -275,16 +276,16 @@ namespace indice.Edi.Tests.Models
         //[EdiValue("9(10)", Path = "BTL/0")]
         //public decimal TotalPaymentDetails { get; set; }
 
-        [EdiValue("9(10)", Path = "BTL/1")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "BTL/1")]
         public decimal TotalChargeBeforeVat { get; set; }
 
-        [EdiValue("9(10)", Path = "BTL/2")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "BTL/2")]
         public decimal BillTotalVatAmmoutPayable { get; set; }
 
         //[EdiValue("9(10)", Path = "BTL/3")]
         //public decimal BalanceBroughtForward { get; set; }
 
-        [EdiValue("9(10)", Path = "BTL/4")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "BTL/4")]
         public decimal TotalBillAmountPayable { get; set; }
         public override string ToString() {
             return string.Format("Net:{0} Vat:{1} Gross:{2}", TotalChargeBeforeVat, BillTotalVatAmmoutPayable, TotalBillAmountPayable);
@@ -314,13 +315,13 @@ namespace indice.Edi.Tests.Models
                 _distributorsIdentifier.Add("TR", "TRANSCO");
             }
         }
-        [EdiValue("9(10)", Path = "MAN/0", Description = "SEQA")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "MAN/0", Description = "SEQA")]
         public int FirstLevelSequenceNumber { get; set; }
 
-        [EdiValue("9(10)", Path = "MAN/1", Description = "SEQB")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "MAN/1", Description = "SEQB")]
         public int SecondLevelSequenceNumber { get; set; }
 
-        [EdiValue("X(2)", Path = "MAN/2/0", Description = "MADN")]
+        [EdiValue("X(2)", FormatterType.PictureSpec, Path = "MAN/2/0", Description = "MADN")]
         public string DistributorIdentifier { get; set; }
         public string DistributorName {
             get {
@@ -332,25 +333,25 @@ namespace indice.Edi.Tests.Models
             }
         }
 
-        [EdiValue("X(10)", Path = "MAN/2/1", Description = "MADN")]
+        [EdiValue("X(10)", FormatterType.PictureSpec, Path = "MAN/2/1", Description = "MADN")]
         public string UniqueReferenceNumber { get; set; }
 
-        [EdiValue("9(1)", Path = "MAN/2/2", Description = "MADN")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MAN/2/2", Description = "MADN")]
         public int? CheckDigit { get; set; }
 
-        [EdiValue("9(2)", Path = "MAN/2/3", Description = "MADN")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "MAN/2/3", Description = "MADN")]
         public int? ProfileType { get; set; }
 
-        [EdiValue("9(3)", Path = "MAN/2/4", Description = "MADN")]
+        [EdiValue("9(3)", FormatterType.PictureSpec, Path = "MAN/2/4", Description = "MADN")]
         public int? MeterTimeSwitchDetails { get; set; }
 
-        [EdiValue("9(3)", Path = "MAN/2/5", Description = "MADN")]
+        [EdiValue("9(3)", FormatterType.PictureSpec, Path = "MAN/2/5", Description = "MADN")]
         public int? LineLossFactor { get; set; }
 
-        [EdiValue("X(35)", Path = "MAN/3", Description = "MTNR")]
+        [EdiValue("X(35)", FormatterType.PictureSpec, Path = "MAN/3", Description = "MTNR")]
         public string MeterSerialNumber { get; set; }
 
-        [EdiValue("9(1)", Path = "MAN/4", Description = "NDIG")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "MAN/4", Description = "NDIG")]
         public int? NumberOfDigits { get; set; }
 
         public override string ToString() {
@@ -362,34 +363,34 @@ namespace indice.Edi.Tests.Models
     [EdiSegment, EdiPath("VAT")]
     public class UtilityBillValueAddedTax
     {
-        [EdiValue("9(10)", Path = "VAT/0", Description = "SEQA")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "VAT/0", Description = "SEQA")]
         public int FirstLevelSequenceNumber { get; set; }
 
-        [EdiValue("9(3)", Path = "VAT/1", Description = "NDVT")]
+        [EdiValue("9(3)", FormatterType.PictureSpec, Path = "VAT/1", Description = "NDVT")]
         public int? NumberOfDays { get; set; }
 
-        [EdiValue("9(3)V9(3)", Path = "VAT/2", Description = "PNDP")]
+        [EdiValue("9(3)V9(3)", FormatterType.PictureSpec, Path = "VAT/2", Description = "PNDP")]
         public decimal? PercentageQualifyingFor { get; set; }
 
-        [EdiValue("X(1)", Path = "VAT/3", Description = "VATC")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "VAT/3", Description = "VATC")]
         public VatRateCategoryCode VatRateCategoryCode { get; set; }
 
-        [EdiValue("9(3)", Path = "VAT/4", Description = "VATP")]
+        [EdiValue("9(3)", FormatterType.PictureSpec, Path = "VAT/4", Description = "VATP")]
         public decimal VatRatePercentage { get; set; }
 
-        [EdiValue("9(10)", Path = "VAT/5/0", Description = "UVLA")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "VAT/5/0", Description = "UVLA")]
         public decimal TotalChargeBeforeVat { get; set; }
 
-        [EdiValue("9(10)", Path = "VAT/6/0", Description = "UVTT")]
+        [EdiValue("9(10)", FormatterType.PictureSpec, Path = "VAT/6/0", Description = "UVTT")]
         public decimal VatAmmountPayable { get; set; }
 
-        [EdiValue("9(10)V9(2)", Path = "VAT/7/0", Description = "UCSI")]
+        [EdiValue("9(10)V9(2)", FormatterType.PictureSpec, Path = "VAT/7/0", Description = "UCSI")]
         public decimal TotalChargeIncludingVat { get; set; }
 
-        [EdiValue("9(4)", Path = "VAT/8", Description = "NRIL")]
+        [EdiValue("9(4)", FormatterType.PictureSpec, Path = "VAT/8", Description = "NRIL")]
         public int? NumberOfItemLines { get; set; }
 
-        [EdiValue("X(3)", Path = "VAT/9", Description = "RFLV")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "VAT/9", Description = "RFLV")]
         public ReasonForLowerVatRateType ReasonForLowerZeroVatRate { get; set; }//null-able
 
         public override string ToString() {
@@ -400,25 +401,25 @@ namespace indice.Edi.Tests.Models
     [EdiSegment, EdiPath("CDA")]
     public class ContractData
     {
-        [EdiValue("X(17)", Path = "CDA/0", Description = "CPSC")]
+        [EdiValue("X(17)", FormatterType.PictureSpec, Path = "CDA/0", Description = "CPSC")]
         public string CurrentPriceScheduleReference { get; set; }
 
-        [EdiValue("X(17)", Path = "CDA/1/0", Description = "ORNO")]
+        [EdiValue("X(17)", FormatterType.PictureSpec, Path = "CDA/1/0", Description = "ORNO")]
         public string CustomerOrderNumber { get; set; }
 
-        [EdiValue("X(17)", Path = "CDA/1/1", Description = "ORNO")]
+        [EdiValue("X(17)", FormatterType.PictureSpec, Path = "CDA/1/1", Description = "ORNO")]
         public string SupplierOrderNumber { get; set; }
 
-        [EdiValue("9(6)", Path = "CDA/1/2", Format = "yyMMdd", Description = "ORNO")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CDA/1/2", Format = "yyMMdd", Description = "ORNO")]
         public DateTime? DateOrderedPlacedByCustomer { get; set; }
 
-        [EdiValue("9(6)", Path = "CDA/1/3", Format = "yyMMdd", Description = "ORNO")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CDA/1/3", Format = "yyMMdd", Description = "ORNO")]
         public DateTime? DateOrderedReceivedBySupplier { get; set; }
 
-        [EdiValue("9(6)", Path = "CDA/2", Format = "yyMMdd", Description = "INSD")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "CDA/2", Format = "yyMMdd", Description = "INSD")]
         public DateTime? InstallationDate { get; set; }
 
-        [EdiValue("X(3)", Path = "CDA/3", Description = "REPE")]
+        [EdiValue("X(3)", FormatterType.PictureSpec, Path = "CDA/3", Description = "REPE")]
         public string RentalPeriod { get; set; }
 
         public override string ToString() {

--- a/test/indice.Edi.Tests/Models/X12_214.cs
+++ b/test/indice.Edi.Tests/Models/X12_214.cs
@@ -3,58 +3,59 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Tests.Models
 {
     public class Transportation_214
     {
-        [EdiValue("9(2)", Path = "ISA/0", Description = "I01 - Authorization Information Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/0", Description = "I01 - Authorization Information Qualifier")]
         public int AuthorizationInformationQualifier { get; set; }
-        [EdiValue("X(10)", Path = "ISA/1", Description = "")]
+        [EdiValue("X(10)", FormatterType.PictureSpec, Path = "ISA/1", Description = "")]
         public string AuthorizationInformation { get; set; }
-        [EdiValue("9(2)", Path = "ISA/2", Description = "I03 - Security Information Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/2", Description = "I03 - Security Information Qualifier")]
         public string Security_Information_Qualifier { get; set; }
 
-        [EdiValue("X(10)", Path = "ISA/3", Description = "I04 - Security Information")]
+        [EdiValue("X(10)", FormatterType.PictureSpec, Path = "ISA/3", Description = "I04 - Security Information")]
         public string Security_Information { get; set; }
 
-        [EdiValue("9(2)", Path = "ISA/4", Description = "I05 - Interchange ID Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/4", Description = "I05 - Interchange ID Qualifier")]
         public string ID_Qualifier { get; set; }
 
-        [EdiValue("X(15)", Path = "ISA/5", Description = "I06 - Interchange Sender ID")]
+        [EdiValue("X(15)", FormatterType.PictureSpec, Path = "ISA/5", Description = "I06 - Interchange Sender ID")]
         public string Sender_ID { get; set; }
 
-        [EdiValue("9(2)", Path = "ISA/6", Description = "I05 - Interchange ID Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/6", Description = "I05 - Interchange ID Qualifier")]
         public string ID_Qualifier2 { get; set; }
 
-        [EdiValue("X(15)", Path = "ISA/7", Description = "I07 - Interchange Receiver ID")]
+        [EdiValue("X(15)", FormatterType.PictureSpec, Path = "ISA/7", Description = "I07 - Interchange Receiver ID")]
         public string Receiver_ID { get; set; }
 
-        [EdiValue("9(6)", Path = "ISA/8", Format = "yyMMdd", Description = "I08 - Interchange Date")]
-        [EdiValue("9(4)", Path = "ISA/9", Format = "HHmm", Description = "TI09 - Interchange Time")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "ISA/8", Format = "yyMMdd", Description = "I08 - Interchange Date")]
+        [EdiValue("9(4)", FormatterType.PictureSpec, Path = "ISA/9", Format = "HHmm", Description = "TI09 - Interchange Time")]
         public DateTime Date { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/10", Description = "I10 - Interchange Control Standards ID")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/10", Description = "I10 - Interchange Control Standards ID")]
         public string Control_Standards_ID { get; set; }
 
-        [EdiValue("9(5)", Path = "ISA/11", Description = "I11 - Interchange Control Version Num")]
+        [EdiValue("9(5)", FormatterType.PictureSpec, Path = "ISA/11", Description = "I11 - Interchange Control Version Num")]
         public int ControlVersion { get; set; }
 
-        [EdiValue("9(9)", Path = "ISA/12", Description = "I12 - Interchange Control Number")]
+        [EdiValue("9(9)", FormatterType.PictureSpec, Path = "ISA/12", Description = "I12 - Interchange Control Number")]
         public int ControlNumber { get; set; }
 
-        [EdiValue("9(1)", Path = "ISA/13", Description = "I13 - Acknowledgement Requested")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "ISA/13", Description = "I13 - Acknowledgement Requested")]
         public bool? AcknowledgementRequested { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/14", Description = "I14 - Usage Indicator")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/14", Description = "I14 - Usage Indicator")]
         public string Usage_Indicator { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/15", Description = "I15 - Component Element Separator")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/15", Description = "I15 - Component Element Separator")]
         public char? Component_Element_Separator { get; set; }
-        [EdiValue("9(1)", Path = "IEA/0", Description = "I16 - Num of Included Functional Grps")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "IEA/0", Description = "I16 - Num of Included Functional Grps")]
         public int GroupsCount { get; set; }
 
-        [EdiValue("9(9)", Path = "IEA/1", Description = "I12 - Interchange Control Number")]
+        [EdiValue("9(9)", FormatterType.PictureSpec, Path = "IEA/1", Description = "I12 - Interchange Control Number")]
         public int TrailerControlNumber { get; set; }
 
         public List<FunctionalGroup> Groups { get; set; }
@@ -62,34 +63,34 @@ namespace indice.Edi.Tests.Models
         [EdiGroup]
         public class FunctionalGroup
         {
-            [EdiValue("X(2)", Path = "GS/0", Description = "479 - Functional Identifier Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/0", Description = "479 - Functional Identifier Code")]
             public string FunctionalIdentifierCode { get; set; }
 
-            [EdiValue("X(15)", Path = "GS/1", Description = "142 - Application Sender's Code")]
+            [EdiValue("X(15)", FormatterType.PictureSpec, Path = "GS/1", Description = "142 - Application Sender's Code")]
             public string ApplicationSenderCode { get; set; }
 
-            [EdiValue("X(15)", Path = "GS/2", Description = "124 - Application Receiver's Code")]
+            [EdiValue("X(15)", FormatterType.PictureSpec, Path = "GS/2", Description = "124 - Application Receiver's Code")]
             public string ApplicationReceiverCode { get; set; }
 
-            [EdiValue("9(8)", Path = "GS/3", Format = "yyyyMMdd", Description = "373 - Date")]
-            [EdiValue("9(4)", Path = "GS/4", Format = "HHmm", Description = "337 - Time")]
+            [EdiValue("9(8)", FormatterType.PictureSpec, Path = "GS/3", Format = "yyyyMMdd", Description = "373 - Date")]
+            [EdiValue("9(4)", FormatterType.PictureSpec, Path = "GS/4", Format = "HHmm", Description = "337 - Time")]
             public DateTime Date { get; set; }
 
-            [EdiValue("9(9)", Path = "GS/5", Format = "HHmm", Description = "28 - Group Control Number")]
+            [EdiValue("9(9)", FormatterType.PictureSpec, Path = "GS/5", Format = "HHmm", Description = "28 - Group Control Number")]
             public int GroupControlNumber { get; set; }
 
-            [EdiValue("X(2)", Path = "GS/6", Format = "HHmm", Description = "455 Responsible Agency Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/6", Format = "HHmm", Description = "455 Responsible Agency Code")]
             public string AgencyCode { get; set; }
 
-            [EdiValue("X(2)", Path = "GS/7", Format = "HHmm", Description = "480 Version / Release / Industry Identifier Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/7", Format = "HHmm", Description = "480 Version / Release / Industry Identifier Code")]
             public string Version { get; set; }
 
             public List<Message> Messages { get; set; }
 
-            [EdiValue("9(1)", Path = "GE/0", Description = "97 Number of Transaction Sets Included")]
+            [EdiValue("9(1)", FormatterType.PictureSpec, Path = "GE/0", Description = "97 Number of Transaction Sets Included")]
             public int TransactionsCount { get; set; }
 
-            [EdiValue("9(9)", Path = "GE/1", Description = "28 Group Control Number")]
+            [EdiValue("9(9)", FormatterType.PictureSpec, Path = "GE/1", Description = "28 Group Control Number")]
             public int GroupTrailerControlNumber { get; set; }
 
 
@@ -99,30 +100,30 @@ namespace indice.Edi.Tests.Models
         [EdiMessage]
         public class Message
         {
-            [EdiValue("9(3)", Path = "ST/00", Description = "")]
+            [EdiValue("9(3)", FormatterType.PictureSpec, Path = "ST/00", Description = "")]
             public int IdentifierCode { get; set; }
-            [EdiValue("X(9)", Path = "ST/01", Description = "")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "ST/01", Description = "")]
             public string ControlNumber { get; set; }
 
-            [EdiValue("9(30)", Path = "B10/0")]
+            [EdiValue("9(30)", FormatterType.PictureSpec, Path = "B10/0")]
             public int ReferenceIdentification { get; set; }
 
             public List<Place> Places { get; set; }
 
-            [EdiValue("9(1)", Path = "SE/0", Description = "96 Number of Segments Included")]
+            [EdiValue("9(1)", FormatterType.PictureSpec, Path = "SE/0", Description = "96 Number of Segments Included")]
             public int MessageSegmetsCount { get; set; }
 
-            [EdiValue("X(9)", Path = "SE/1", Description = "329 Transaction Set Control Number")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "SE/1", Description = "329 Transaction Set Control Number")]
             public string MessageControlNumber { get; set; }
         }
 
         [EdiSegment, EdiSegmentGroup("N1", SequenceEnd = "LX")]
         public class Place
         {
-            [EdiValue("X(9)", Path = "N1/0", Description = "")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "N1/0", Description = "")]
             public string FieldValue1 { get; set; }
 
-            [EdiValue("X(9)", Path = "N3/0", Description = "")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "N3/0", Description = "")]
             public string FieldValue2 { get; set; }
         }
 

--- a/test/indice.Edi.Tests/Models/X12_850.cs
+++ b/test/indice.Edi.Tests/Models/X12_850.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using indice.Edi.FormatSpec;
 
 namespace indice.Edi.Tests.Models
 {
@@ -13,56 +14,56 @@ namespace indice.Edi.Tests.Models
     {
 
         #region ISA and IEA
-        [EdiValue("9(2)", Path = "ISA/0", Description = "ISA01 - Authorization Information Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/0", Description = "ISA01 - Authorization Information Qualifier")]
         public int AuthorizationInformationQualifier { get; set; }
 
-        [EdiValue("X(10)", Path = "ISA/1", Description = "ISA02 - Authorization Information")]
+        [EdiValue("X(10)", FormatterType.PictureSpec, Path = "ISA/1", Description = "ISA02 - Authorization Information")]
         public string AuthorizationInformation { get; set; }
 
-        [EdiValue("9(2)", Path = "ISA/2", Description = "ISA03 - Security Information Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/2", Description = "ISA03 - Security Information Qualifier")]
         public string Security_Information_Qualifier { get; set; }
 
-        [EdiValue("X(10)", Path = "ISA/3", Description = "ISA04 - Security Information")]
+        [EdiValue("X(10)", FormatterType.PictureSpec, Path = "ISA/3", Description = "ISA04 - Security Information")]
         public string Security_Information { get; set; }
 
-        [EdiValue("9(2)", Path = "ISA/4", Description = "ISA05 - Interchange ID Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/4", Description = "ISA05 - Interchange ID Qualifier")]
         public string ID_Qualifier { get; set; }
 
-        [EdiValue("X(15)", Path = "ISA/5", Description = "ISA06 - Interchange Sender ID")]
+        [EdiValue("X(15)", FormatterType.PictureSpec, Path = "ISA/5", Description = "ISA06 - Interchange Sender ID")]
         public string Sender_ID { get; set; }
 
-        [EdiValue("9(2)", Path = "ISA/6", Description = "ISA07 - Interchange ID Qualifier")]
+        [EdiValue("9(2)", FormatterType.PictureSpec, Path = "ISA/6", Description = "ISA07 - Interchange ID Qualifier")]
         public string ID_Qualifier2 { get; set; }
 
-        [EdiValue("X(15)", Path = "ISA/7", Description = "ISA08 - Interchange Receiver ID")]
+        [EdiValue("X(15)", FormatterType.PictureSpec, Path = "ISA/7", Description = "ISA08 - Interchange Receiver ID")]
         public string Receiver_ID { get; set; }
 
-        [EdiValue("9(6)", Path = "ISA/8", Format = "yyMMdd", Description = "I09 - Interchange Date")]
-        [EdiValue("9(4)", Path = "ISA/9", Format = "HHmm", Description = "I10 - Interchange Time")]
+        [EdiValue("9(6)", FormatterType.PictureSpec, Path = "ISA/8", Format = "yyMMdd", Description = "I09 - Interchange Date")]
+        [EdiValue("9(4)", FormatterType.PictureSpec, Path = "ISA/9", Format = "HHmm", Description = "I10 - Interchange Time")]
         public DateTime Date { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/10", Description = "ISA11 - Interchange Control Standards ID")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/10", Description = "ISA11 - Interchange Control Standards ID")]
         public string Control_Standards_ID { get; set; }
 
-        [EdiValue("9(5)", Path = "ISA/11", Description = "ISA12 - Interchange Control Version Num")]
+        [EdiValue("9(5)", FormatterType.PictureSpec, Path = "ISA/11", Description = "ISA12 - Interchange Control Version Num")]
         public int ControlVersion { get; set; }
 
-        [EdiValue("9(9)", Path = "ISA/12", Description = "ISA13 - Interchange Control Number")]
+        [EdiValue("9(9)", FormatterType.PictureSpec, Path = "ISA/12", Description = "ISA13 - Interchange Control Number")]
         public int ControlNumber { get; set; }
 
-        [EdiValue("9(1)", Path = "ISA/13", Description = "ISA14 - Acknowledgement Requested")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "ISA/13", Description = "ISA14 - Acknowledgement Requested")]
         public bool? AcknowledgementRequested { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/14", Description = "ISA15 - Usage Indicator")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/14", Description = "ISA15 - Usage Indicator")]
         public string Usage_Indicator { get; set; }
 
-        [EdiValue("X(1)", Path = "ISA/15", Description = "ISA16 - Component Element Separator")]
+        [EdiValue("X(1)", FormatterType.PictureSpec, Path = "ISA/15", Description = "ISA16 - Component Element Separator")]
         public char? Component_Element_Separator { get; set; }
 
-        [EdiValue("9(1)", Path = "IEA/0", Description = "IEA01 - Num of Included Functional Grps")]
+        [EdiValue("9(1)", FormatterType.PictureSpec, Path = "IEA/0", Description = "IEA01 - Num of Included Functional Grps")]
         public int GroupsCount { get; set; }
 
-        [EdiValue("9(9)", Path = "IEA/1", Description = "IEA02 - Interchange Control Number")]
+        [EdiValue("9(9)", FormatterType.PictureSpec, Path = "IEA/1", Description = "IEA02 - Interchange Control Number")]
         public int TrailerControlNumber { get; set; }
 
         #endregion
@@ -73,35 +74,35 @@ namespace indice.Edi.Tests.Models
         public class FunctionalGroup
         {
 
-            [EdiValue("X(2)", Path = "GS/0", Description = "GS01 - Functional Identifier Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/0", Description = "GS01 - Functional Identifier Code")]
             public string FunctionalIdentifierCode { get; set; }
 
-            [EdiValue("X(15)", Path = "GS/1", Description = "GS02 - Application Sender's Code")]
+            [EdiValue("X(15)", FormatterType.PictureSpec, Path = "GS/1", Description = "GS02 - Application Sender's Code")]
             public string ApplicationSenderCode { get; set; }
 
-            [EdiValue("X(15)", Path = "GS/2", Description = "GS03 - Application Receiver's Code")]
+            [EdiValue("X(15)", FormatterType.PictureSpec, Path = "GS/2", Description = "GS03 - Application Receiver's Code")]
             public string ApplicationReceiverCode { get; set; }
 
-            [EdiValue("9(8)", Path = "GS/3", Format = "yyyyMMdd", Description = "GS04 - Date")]
-            [EdiValue("9(4)", Path = "GS/4", Format = "HHmm", Description = "GS05 - Time")]
+            [EdiValue("9(8)", FormatterType.PictureSpec, Path = "GS/3", Format = "yyyyMMdd", Description = "GS04 - Date")]
+            [EdiValue("9(4)", FormatterType.PictureSpec, Path = "GS/4", Format = "HHmm", Description = "GS05 - Time")]
             public DateTime Date { get; set; }
 
-            [EdiValue("9(9)", Path = "GS/5", Format = "HHmm", Description = "GS06 - Group Control Number")]
+            [EdiValue("9(9)", FormatterType.PictureSpec, Path = "GS/5", Format = "HHmm", Description = "GS06 - Group Control Number")]
             public int GroupControlNumber { get; set; }
 
-            [EdiValue("X(2)", Path = "GS/6", Format = "HHmm", Description = "GS07 Responsible Agency Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/6", Format = "HHmm", Description = "GS07 Responsible Agency Code")]
             public string AgencyCode { get; set; }
 
-            [EdiValue("X(2)", Path = "GS/7", Format = "HHmm", Description = "GS08 Version / Release / Industry Identifier Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "GS/7", Format = "HHmm", Description = "GS08 Version / Release / Industry Identifier Code")]
             public string Version { get; set; }
 
             public List<Order> Orders { get; set; }
 
 
-            [EdiValue("9(1)", Path = "GE/0", Description = "97 Number of Transaction Sets Included")]
+            [EdiValue("9(1)", FormatterType.PictureSpec, Path = "GE/0", Description = "97 Number of Transaction Sets Included")]
             public int TransactionsCount { get; set; }
 
-            [EdiValue("9(9)", Path = "GE/1", Description = "28 Group Control Number")]
+            [EdiValue("9(9)", FormatterType.PictureSpec, Path = "GE/1", Description = "28 Group Control Number")]
             public int GroupTrailerControlNumber { get; set; }
         }
 
@@ -110,35 +111,35 @@ namespace indice.Edi.Tests.Models
         {
             #region Header Trailer
 
-            [EdiValue("X(3)", Path = "ST/0", Description = "ST01 - Transaction set ID code")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "ST/0", Description = "ST01 - Transaction set ID code")]
             public string TransactionSetCode { get; set; }
 
-            [EdiValue("X(9)", Path = "ST/1", Description = "ST02 - Transaction set control number")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "ST/1", Description = "ST02 - Transaction set control number")]
             public string TransactionSetControlNumber { get; set; }
 
             [EdiValue(Path = "SE/0", Description = "SE01 - Number of included segments")]
             public int SegmentsCouts { get; set; }
 
-            [EdiValue("X(9)", Path = "SE/1", Description = "SE02 - Transaction set control number (same as ST02)")]
+            [EdiValue("X(9)", FormatterType.PictureSpec, Path = "SE/1", Description = "SE02 - Transaction set control number (same as ST02)")]
             public string TrailerTransactionSetControlNumber { get; set; } 
             #endregion
 
-            [EdiValue("X(2)", Path = "BEG/0", Description = "BEG01 - Trans. Set Purpose Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "BEG/0", Description = "BEG01 - Trans. Set Purpose Code")]
             public string TransSetPurposeCode { get; set; }
 
-            [EdiValue("X(2)", Path = "BEG/1", Description = "BEG02 - Purchase Order Type Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "BEG/1", Description = "BEG02 - Purchase Order Type Code")]
             public string PurchaseOrderTypeCode { get; set; }
 
             [EdiValue(Path = "BEG/2", Description = "BEG03 - Purchase Order Number")]
             public string PurchaseOrderNumber { get; set; }
 
-            [EdiValue("9(8)", Path = "BEG/4", Format = "yyyyMMdd", Description = "BEG05 - Purchase Order Date")]
+            [EdiValue("9(8)", FormatterType.PictureSpec, Path = "BEG/4", Format = "yyyyMMdd", Description = "BEG05 - Purchase Order Date")]
             public string PurchaseOrderDate { get; set; }
 
             [EdiValue(Path = "CUR/0", Description = "CUR01 - Entity Identifier Code")]
             public string EntityIdentifierCode { get; set; }
 
-            [EdiValue("X(3)", Path = "CUR/1", Description = "CUR02 - Currency Code")]
+            [EdiValue("X(3)", FormatterType.PictureSpec, Path = "CUR/1", Description = "CUR02 - Currency Code")]
             public string CurrencyCode { get; set; }
 
             [EdiValue(Path = "REF/0", Description = "REF01 - Reference Identification Qualifier IA – Vendor Number assigned by Carhartt")]
@@ -153,7 +154,7 @@ namespace indice.Edi.Tests.Models
             [EdiValue(Path = "FOB/5", Description = "FOB06 - Code identifying type of location KL – Port of loading")]
             public string LocationQualifier { get; set; }
 
-            [EdiValue("X(2)", Path = "ITD/0", Description = "ITD01 - Terms Type Code")]
+            [EdiValue("X(2)", FormatterType.PictureSpec, Path = "ITD/0", Description = "ITD01 - Terms Type Code")]
             public string TermsTypeCode { get; set; }
 
             [EdiValue(Path = "ITD/1", Description = "ITD02 - Terms Basis Date Code")]
@@ -244,7 +245,7 @@ namespace indice.Edi.Tests.Models
             [EdiValue(Path = "DTM/0", Description = "DTM01 - Date/Time Qualifier")]
             public string DateTimeQualifier { get; set; }
 
-            [EdiValue("9(8)", Path = "DTM/1", Format = "yyyyMMdd", Description = "DTM02 - Date format =CCYYMMDD")]
+            [EdiValue("9(8)", FormatterType.PictureSpec, Path = "DTM/1", Format = "yyyyMMdd", Description = "DTM02 - Date format =CCYYMMDD")]
             public DateTime Date { get; set; }
         }
 

--- a/test/indice.Edi.Tests/ToEdiStringTests.cs
+++ b/test/indice.Edi.Tests/ToEdiStringTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using indice.Edi.FormatSpec;
 using Xunit;
 
 namespace indice.Edi.Tests
@@ -12,11 +13,11 @@ namespace indice.Edi.Tests
         [Fact]
         [Trait(Traits.Tag, "Parser")]
         public void IntegerToStringTest() {
-            Assert.Equal("   12", EdiExtensions.ToEdiString(12, (Picture)"X(5)"));
-            Assert.Equal("00012", EdiExtensions.ToEdiString(12, (Picture)"9(5)"));
-            Assert.Equal("00012", EdiExtensions.ToEdiString(12, (Picture)"9(5)"));
-            Assert.Equal("12", EdiExtensions.ToEdiString(12, (Picture)"X(1)"));
-            Assert.Equal("12", EdiExtensions.ToEdiString(12, (Picture)"9(1)"));
+            Assert.Equal("   12", EdiExtensions.ToEdiString(12, (PictureSpec)"X(5)"));
+            Assert.Equal("00012", EdiExtensions.ToEdiString(12, (PictureSpec)"9(5)"));
+            Assert.Equal("00012", EdiExtensions.ToEdiString(12, (PictureSpec)"9(5)"));
+            Assert.Equal("12", EdiExtensions.ToEdiString(12, (PictureSpec)"X(1)"));
+            Assert.Equal("12", EdiExtensions.ToEdiString(12, (PictureSpec)"9(1)"));
         }
     }
 }


### PR DESCRIPTION
When implementing a protocol using an message implementation guide it is nice to follow the notation of the specs. As I understand the PICTURE notation is used for implementation guides for Tradacoms based protocols. The edifact implementation guides follow the following structures:

> a       alphabetic characters
n       numeric characters
an      alpha-numeric characters
a3      3 alphabetic characters, fixed length
n3      3 numeric characters, fixed length
an3     3 alpha-numeric characters, fixed length
a..3    up to 3 alphabetic characters, variable length
n..3    up to 3 numeric characters, variable length
an..3   up to 3 alpha-numeric characters, variable length

As I would like to create my POCO classes using the edifact notation I created an interface 'IFormatSpec' that is now implemented by PictureSpec and by the newly created EdifactSpec. 

The same formatting can now be achieved in 2 notations:
` [EdiValue("n3", FormatterType.EdifactSpec, Path = "DTM/0/0")]`
or
`[EdiValue("9(3)", FormatterType.PictureSpec, Path = "DTM/0/0")]`

The difference is that the picture notation cannot support variable length so the Picuture class sets the VariableLength always to false in its class so the write can use the IFormatSpec interface and add padding to all EdiValues defined in the Picture notation. The EdiSpec looks for .. in the specification string and sets the VariableLength accordingly.

I'm not so happy with the fact that an enum has to be provided to the EdiValue attribute to switch between the EdifactSpec and PictureSpec but I didn't find a nicer solution for this at this moment. 
The EdiValueAttribute class is an sealed attribute at this moment and I think that is for a reason, otherwise a new class could extend EdiValueAttribute and set the type enum when calling its base constructor. It is also possible to differentiate between the two notations using some regex to determine either picture or edifact notation, but it feels wasteful to use resources for this determination.

This pull requests main purpose is to collect feedback on this first attempt of an format refactor.
 
Releated to #23 and #43 