### PR TITLE
Feature: Optional AutoClose on impicit segment

### DIFF
--- a/src/indice.Edi/EdiSerializer.cs
+++ b/src/indice.Edi/EdiSerializer.cs
@@ -24,6 +24,12 @@ namespace indice.Edi
         public bool AutoEndSegmentGroups { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether segment groups should automatically end when a non-matching segment is found even if the segment is a implicid segment. 
+        /// </summary>
+        public bool AutoEndSegmentGroupsOnImplicitSegments { get; set; }
+
+
+        /// <summary>
         /// Deserializes the EDI structure contained by the specified <see cref="EdiReader"/>.
         /// </summary>
         /// <param name="reader">The <see cref="EdiReader"/> that contains the EDI structure to deserialize.</param>
@@ -128,7 +134,7 @@ namespace indice.Edi
                         while (true) {
                             if (TryCreateContainer(reader, stack, EdiStructureType.SegmentGroup)
                                 || TryCreateContainer(reader, stack, EdiStructureType.Segment)
-                                || implicitSegments.Contains(reader.Value)
+                                || (implicitSegments.Contains(reader.Value) && !AutoEndSegmentGroupsOnImplicitSegments)
                                 || !AutoEndSegmentGroups) {
                                 break;
                             }

--- a/test/indice.Edi.Tests/Edifact_AutoEndSegmentGroups.cs
+++ b/test/indice.Edi.Tests/Edifact_AutoEndSegmentGroups.cs
@@ -16,7 +16,7 @@ namespace indice.Edi.Tests
             var interchange = default(AutoEndSegmentGroups);
 
             using (var stream = Helpers.GetResourceStream("edifact.AutoEndSegmentGroups.edi")) {
-                var serializer = new EdiSerializer {AutoEndSegmentGroups = true};
+                var serializer = new EdiSerializer { AutoEndSegmentGroups = true };
                 interchange = serializer.Deserialize<AutoEndSegmentGroups>(new StreamReader(stream), grammar);
             }
 
@@ -31,5 +31,20 @@ namespace indice.Edi.Tests
             Assert.NotNull(message.AfterGroup);
             Assert.Equal(message.AfterGroup.Id, "Message1.AfterGroup");
         }
+
+        [Fact]
+        [Trait(Traits.Tag, "EDIFact")]
+        public void AutoEndSegmentGroupsImplicitSegments() {
+            var grammar = EdiGrammar.NewEdiFact();
+            var interchange = default(AutoEndSegmentGroups);
+
+            Assert.Throws<EdiException>(() => {
+                using (var stream = Helpers.GetResourceStream("edifact.AutoEndSegmentGroups.edi")) {
+                    var serializer = new EdiSerializer { AutoEndSegmentGroups = true, AutoEndSegmentGroupsOnImplicitSegments = true };
+                    interchange = serializer.Deserialize<AutoEndSegmentGroups>(new StreamReader(stream), grammar);
+                }
+            });
+        }
+
     }
 }


### PR DESCRIPTION
When using AutoClose, also allow auto closing on implicit segments (e.g: MessageHeader, MessageTrailer, etc.)