### PR TITLE
Feature: Make it possible to inherit a SegmentGroup from the first Segment

### DIFF
--- a/src/indice.Edi/Serialization/EdiTypeDescriptor.cs
+++ b/src/indice.Edi/Serialization/EdiTypeDescriptor.cs
@@ -43,7 +43,9 @@ namespace indice.Edi.Serialization
         public EdiTypeDescriptor(Type clrType) {
             _ClrType = clrType;
             _Properties = new List<EdiPropertyDescriptor>();
-            var props = ClrType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(pi => new EdiPropertyDescriptor(pi)).Where(pi => pi.Attributes.Any());
+            // list inherited properties first; so SegmentGroups can inherit from there first Segment
+            var clrProps = ClrType.GetProperties(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.DeclaringType == clrType);
+            var props = clrProps.Select(pi => new EdiPropertyDescriptor(pi)).Where(pi => pi.Attributes.Any());
             // support for multiple value attributes on the same property. Bit hacky.
             foreach (var p in props) {
                 var valueAttributes = p.Attributes.OfType<EdiValueAttribute>().ToArray();

--- a/test/indice.Edi.Tests/InheritSegmentGroupTest.cs
+++ b/test/indice.Edi.Tests/InheritSegmentGroupTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using indice.Edi.Tests.Models;
+using Xunit;
+
+namespace indice.Edi.Tests
+{
+    public class InheritSegmentGroupTest
+    {
+        [Fact]
+        public void InheritSegmentGroup() {
+            var grammar = EdiGrammar.NewEdiFact();
+            var interchange = new InheritSegmentGroup();
+            interchange.Messages = new List<Models.InheritSegmentGroup.Message>();
+            var msg = new InheritSegmentGroup.Message();
+            msg.Id = "Group1";
+            msg.Element = new Models.InheritSegmentGroup.InGroup();
+            msg.Element.Id = "Element1";
+            interchange.Messages.Add(msg);
+
+            string output = null;
+            using (var writer = new System.IO.StringWriter()) {
+                new EdiSerializer().Serialize(writer, grammar, interchange);
+                output = writer.ToString();
+            }
+
+            var GrpPos = output.IndexOf("Group1");
+            var ElmPos = output.IndexOf("Element1");
+
+            Assert.True(GrpPos >= 0);
+            Assert.True(ElmPos >= 0);
+            Assert.True(GrpPos < ElmPos);
+        }
+    }
+}

--- a/test/indice.Edi.Tests/Models/InheritSegmentGroup.cs
+++ b/test/indice.Edi.Tests/Models/InheritSegmentGroup.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using indice.Edi.Serialization;
+
+namespace indice.Edi.Tests.Models
+{
+    class InheritSegmentGroup
+    {
+        public List<Message> Messages { get; set; }
+
+        [EdiSegment(), EdiPath("GRP")]
+        public class GRP
+        {
+            [EdiValue("X(35)", Path = "GRP/0")]
+            public string Id { get; set; }
+        }
+
+        [EdiSegment, EdiPath("IN1")]
+        public class InGroup
+        {
+            [EdiValue("X(35)", Path = "IN1/0")]
+            public string Id { get; set; }
+        }
+
+        [EdiSegmentGroup("GRP")]
+        public class Message : GRP
+        {
+            public InGroup Element { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I was building some module classes and want to define all segments as classes. The segment-groups than can inherit from there first segment, so they get all the properties. This makes the code for the SegmentGroups very nice.

This is already working when deserializing but it brakes the order when serializing.