### PR TITLE
C# 6 compatibility

### DIFF
--- a/src/indice.Edi/Serialization/EdiConditionAttribute.cs
+++ b/src/indice.Edi/Serialization/EdiConditionAttribute.cs
@@ -134,13 +134,17 @@ namespace indice.Edi.Serialization
         /// <returns></returns>
         public override string ToString() {
             switch (CheckFor) {
-                case EdiConditionCheckType.Equal when Options == null || Options.Length == 1:
-                    return $"Condition = {MatchValue}";
-                case EdiConditionCheckType.NotEqual when Options == null || Options.Length == 1:
-                    return $"Condition != {MatchValue}";
                 case EdiConditionCheckType.Equal:
+                    if(Options == null || Options.Length == 1)
+                    {
+                        return $"Condition = {MatchValue}";
+                    }
                     return $"Condition in ({string.Join(", ", Options)})";
                 case EdiConditionCheckType.NotEqual:
+                    if(Options == null || Options.Length == 1)
+                    {
+                        return $"Condition != {MatchValue}";
+                    }
                     return $"Condition not in ({string.Join(", ", Options)})";
                 default:
                     throw new EdiException($"Unexpected condition type {CheckFor}");

--- a/src/indice.Edi/Utilities/ReflectionUtils.cs
+++ b/src/indice.Edi/Utilities/ReflectionUtils.cs
@@ -574,9 +574,11 @@ namespace indice.Edi.Utilities
         {
             Attribute[] a = GetAttributes(attributeProvider, typeof(T), inherit);
 
-            if (a is T[] attributes)
+            if (a is T[])
+            {
+                var attributes = a as T[];
                 return attributes;
-
+            }
             return a.Cast<T>().ToArray();
         }
 


### PR DESCRIPTION
Hi, I need to maintain C#6 compatibility (VS2015).
Think it makes sence to not enforce VS2017 right now.