### PR TITLE
Fix issue where looped segment could be overwritten with next iteration

### DIFF
--- a/src/indice.Edi/EdiSerializer.cs
+++ b/src/indice.Edi/EdiSerializer.cs
@@ -401,6 +401,11 @@ namespace indice.Edi
                     while (stack.Peek() != clearUpTo) {
                         stack.Pop();
                     }
+
+                    var segmentName = stack.Peek().Descriptor.SegmentGroupInfo?.Members?.FirstOrDefault().Segment;
+                    if ((readerSegment as string) == segmentName) {
+                        stack.Pop();
+                    }
                 }
             } else {
                 // strict hierarchy


### PR DESCRIPTION
In certain situations the deserializer can become confused and not properly end a segment when the next segment in the loop has the same segment identifier. This causes the deserializer not to terminate the segment group and overwrite values with the next segment group.

A good example of this is the case of a `PO1` segment group which has nested `N9` with nested `MTX` segments:
![Example](https://i.imgur.com/ocxJqxq.png)

The proposed patch will determine if a segment group start segment is being repeated and pop it off the stack. This seems to solve the issue without causing any noticeable side effects.

An abbreviated snippet of the model is provided below for reference:
```cs
[EdiSegment, EdiSegmentGroup("PO1", "PID", "ACK", "N9", "MTX")]
public class Interchange_PO1
{
  public List<Interchange_N9_MTX> ExtendedInformation { get; set; }
  
  [EdiSegment, EdiPath("N9")]
  public class Interchange_N9
  {
    [EdiValue(Path = "N9/0", Description = "N901 - Reference Identification Qualifier")]
    public string IdentificationCodeQualifier { get; set; }

    [EdiValue(Path = "N9/1", Description = "N902 - Reference Identification")]
    public string ReferenceIdentification { get; set; }
  }

  [EdiSegment, EdiSegmentGroup("N9", "MTX")]
  public class Interchange_N9_MTX : Interchange_N9
  {
    public List<Interchange_MTX> Text { get; set; }
  }
}
```