### PR TITLE
Use Environment.NewLine when checking certain expected values

### DIFF
--- a/test/indice.Edi.Tests/EdiTextWriterTests.cs
+++ b/test/indice.Edi.Tests/EdiTextWriterTests.cs
@@ -92,7 +92,7 @@ namespace indice.Edi.Tests
         [Fact, Trait(Traits.Tag, "Writer"), Trait(Traits.Issue, "#141")]
         public void WriterWrites_Boolean_Correctly() {
             var grammar = EdiGrammar.NewEdiFact();
-            var expected = new StringBuilder().Append("AAA+1+:0'\r\n");
+            var expected = new StringBuilder().Append($"AAA+1+:0'{Environment.NewLine}");
             var output = new StringBuilder();
             using (var writer = new EdiTextWriter(new StringWriter(output), grammar)) {
                 writer.WriteToken(EdiToken.SegmentName, "AAA"); Assert.Equal("AAA", writer.Path);

--- a/test/indice.Edi.Tests/SerializerTests.cs
+++ b/test/indice.Edi.Tests/SerializerTests.cs
@@ -114,7 +114,7 @@ namespace indice.Edi.Tests
                 }
             };
 
-            var expected = "UNA:+.? '\r\nTSR+++270'";
+            var expected = $"UNA:+.? '{Environment.NewLine}TSR+++270'";
             var output = new StringBuilder();
             var grammar = EdiGrammar.NewEdiFact();
             using (var writer = new EdiTextWriter(new StringWriter(output), grammar)) {
@@ -163,7 +163,7 @@ namespace indice.Edi.Tests
                     }
                 }
             };
-            var expected = "UNA:+.? '\r\nPAC+1+:52+PK'\r\n";
+            var expected = $"UNA:+.? '{Environment.NewLine}PAC+1+:52+PK'{Environment.NewLine}";
             string output = null;
             using (var writer = new StringWriter()) {
                 new EdiSerializer() { EnableCompression = false }.Serialize(writer, grammar, interchange);


### PR DESCRIPTION
There are a couple of different ways to correct this, I used Environment.NewLine so that Windows, Unix, and older Mac OS users would be testing against the appropriate new line character(s).