### PR TITLE
use correct framework

### DIFF
--- a/src/indice.Edi/indice.Edi.csproj
+++ b/src/indice.Edi/indice.Edi.csproj
@@ -6,7 +6,7 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>beta01</VersionSuffix>
     <Authors>c.leftheris</Authors>
-    <TargetFrameworks>netstandard2.1;net60;net80</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>indice.Edi</AssemblyName>
     <AssemblyTitle>Edi.Net</AssemblyTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/indice.Edi.Tests/indice.Edi.Tests.csproj
+++ b/test/indice.Edi.Tests/indice.Edi.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>indice.Edi.Tests Class Library</Description>
-    <TargetFrameworks>net60;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks