### PR TITLE
Add support to write explicit nesting markers

### DIFF
--- a/src/indice.Edi/EdiGrammar.cs
+++ b/src/indice.Edi/EdiGrammar.cs
@@ -146,6 +146,11 @@ public class EdiGrammar : IEdiGrammar
     public string InterchangeTrailerTag { get; protected set; }
 
     /// <summary>
+    /// Whether to print explicit indication of nesting
+    /// </summary>
+    public bool ExplicitIndicationOfNesting { get; set; }
+
+    /// <summary>
     /// Checks to see if a character is any of the known special characters.
     /// </summary>
     /// <param name="character">The character to check</param>

--- a/src/indice.Edi/EdiWriter.cs
+++ b/src/indice.Edi/EdiWriter.cs
@@ -293,7 +293,8 @@ public abstract class EdiWriter : IDisposable
     /// Writes the segmant name. And marks the beginning of a Segment.
     /// </summary>
     /// <param name="name">The name of the segment.</param>
-    public virtual void WriteSegmentName(string name) {
+    /// <param name="nesting">The current nesting level.</param>
+    public virtual void WriteSegmentName(string name, IList<int> nesting) {
         InternalWriteStart(EdiToken.SegmentName, EdiContainerType.Segment);
         InternalWriteSegmentName(name);
     }
@@ -339,7 +340,7 @@ public abstract class EdiWriter : IDisposable
             case EdiToken.SegmentName:
                 // read to next
                 ValidationUtils.ArgumentNotNull(value, nameof(value));
-                WriteSegmentName(value.ToString());
+                WriteSegmentName(value.ToString(), []);
                 break;
             case EdiToken.ElementStart:
                 InternalWriteStart(EdiToken.ElementStart, EdiContainerType.Element);

--- a/src/indice.Edi/IEdiGrammar.cs
+++ b/src/indice.Edi/IEdiGrammar.cs
@@ -116,4 +116,8 @@ public interface IEdiGrammar
                    char? reserved,
                    char? decimalMark);
 
+    /// <summary>
+    /// Whether to print explicit indication of nesting
+    /// </summary>
+    bool ExplicitIndicationOfNesting { get; set; }
 }

--- a/test/indice.Edi.Tests/Models/EDIFACT_ExplicitNesting_issue227.cs
+++ b/test/indice.Edi.Tests/Models/EDIFACT_ExplicitNesting_issue227.cs
@@ -1,0 +1,33 @@
+using indice.Edi.Serialization;
+
+namespace indice.Edi.Tests.Models;
+
+public class EDIFACT_ExplicitNesting_issue227
+{
+    public Message Msg { get; set; }
+
+    [EdiMessage]
+    public class Message
+    {
+        [EdiValue(Mandatory = true, Path = "TIT/0")]
+        public string Title { get; set; }
+        
+        public List<Level1> L1s { get; set; }
+    }
+
+    [EdiSegment]
+    public class Level1
+    {
+        [EdiValue(Mandatory = true, Path = "LE1/0")]
+        public string Name { get; set; }
+        
+        public List<Level2> L2s { get; set; }
+    }
+
+    [EdiSegment]
+    public class Level2
+    {
+        [EdiValue(Path = "LE2/0")]
+        public string SubName { get; set; } 
+    }
+}

--- a/test/indice.Edi.Tests/SerializerTests.cs
+++ b/test/indice.Edi.Tests/SerializerTests.cs
@@ -487,7 +487,7 @@ public class SerializerTests
     }
 
     [Fact, Trait(Traits.Tag, "EDIFact")]
-    public void Serialize_Explicit_Indication_of_Nesting() {
+    public void Serialize_With_Explicit_Indication_of_Nesting() {
         var grammar = EdiGrammar.NewEdiFact();
         grammar.ExplicitIndicationOfNesting = true;
         var interchange = new EDIFACT_ExplicitNesting_issue227() {
@@ -517,13 +517,60 @@ public class SerializerTests
             }
         };
         var expected = new StringBuilder()
-    .AppendLine("UNA:+.? '")
-    .AppendLine("TIT+Title'")
-    .AppendLine("LE1:1+Name 1'")
-    .AppendLine("LE2:1:1+Sub 1 1'")
-    .AppendLine("LE2:1:2+Sub 1 2'")
-    .AppendLine("LE1:2+Name 2'")
-    .AppendLine("LE2:2:1+Sub 2 1'").ToString();
+            .AppendLine("UNA:+.? '")
+            .AppendLine("TIT+Title'")
+            .AppendLine("LE1:1+Name 1'")
+            .AppendLine("LE2:1:1+Sub 1 1'")
+            .AppendLine("LE2:1:2+Sub 1 2'")
+            .AppendLine("LE1:2+Name 2'")
+            .AppendLine("LE2:2:1+Sub 2 1'").ToString();
+        string output = null;
+        using (var writer = new StringWriter()) {
+            new EdiSerializer().Serialize(writer, grammar, interchange);
+            output = writer.ToString();
+        }
+
+        Assert.Equal(expected, output);
+    }
+
+    [Fact, Trait(Traits.Tag, "EDIFact")]
+    public void Serialize_Without_Explicit_Indication_of_Nesting() {
+        var grammar = EdiGrammar.NewEdiFact();
+        grammar.ExplicitIndicationOfNesting = false;
+        var interchange = new EDIFACT_ExplicitNesting_issue227() {
+            Msg = new() {
+                Title = "Title",
+                L1s = [
+                    new() {
+                        Name = "Name 1",
+                        L2s = [
+                            new() {
+                                SubName = "Sub 1 1"
+                            },
+                            new() {
+                                SubName = "Sub 1 2"
+                            }
+                        ]
+                    },
+                    new() {
+                        Name = "Name 2",
+                        L2s = [
+                            new() {
+                                SubName = "Sub 2 1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var expected = new StringBuilder()
+            .AppendLine("UNA:+.? '")
+            .AppendLine("TIT+Title'")
+            .AppendLine("LE1+Name 1'")
+            .AppendLine("LE2+Sub 1 1'")
+            .AppendLine("LE2+Sub 1 2'")
+            .AppendLine("LE1+Name 2'")
+            .AppendLine("LE2+Sub 2 1'").ToString();
         string output = null;
         using (var writer = new StringWriter()) {
             new EdiSerializer().Serialize(writer, grammar, interchange);

--- a/test/indice.Edi.Tests/SerializerTests.cs
+++ b/test/indice.Edi.Tests/SerializerTests.cs
@@ -417,9 +417,8 @@ public class SerializerTests
     public void Serialize_RangeError_Issue190() {
         var grammar = EdiGrammar.NewEdiFact();
 
-        var ok = new EdiFact_Issue190.TIF
-        {
-            Names = new List<EdiFact_Issue190.GivenName> {"Hello", "World"}
+        var ok = new EdiFact_Issue190.TIF {
+            Names = new List<EdiFact_Issue190.GivenName> { "Hello", "World" }
         };
         var okResult = Serialize(ok);
         var okExpected = new StringBuilder().AppendLine("UNA:+.? '").AppendLine("TIF++Hello+World'").ToString();
@@ -427,12 +426,12 @@ public class SerializerTests
 
         var bad = new EdiFact_Issue190.BUGGEDTIF {
             Category = "ADT",
-            Names = new List<EdiFact_Issue190.GivenName> {"Hello", "World"}
+            Names = new List<EdiFact_Issue190.GivenName> { "Hello", "World" }
         };
         var badResult = Serialize(bad);
         var badExpected = new StringBuilder().AppendLine("UNA:+.? '").AppendLine("TIF+:ADT+Hello+World'").ToString();
         Assert.Equal(badExpected, badResult);
-        
+
         string Serialize<T>(T data) {
             using var writer = new StringWriter();
             new EdiSerializer().Serialize(writer, grammar, data);
@@ -449,7 +448,7 @@ public class SerializerTests
         }
         Assert.NotNull(source);
 
-        
+
         string Serialize<T>(T data) {
             var grammar = EdiGrammar.NewEdiFact();
             using var writer = new StringWriter();
@@ -464,7 +463,7 @@ public class SerializerTests
 
     [Fact, Trait(Traits.Tag, "EDIFact"), Trait(Traits.Issue, "#263")]
     public void Serialize_Should_Write_List_Of_Repeating_Elements_Issue235() {
-        var source = new Interchange_Issue263.GIN { 
+        var source = new Interchange_Issue263.GIN {
             Qualifier = "AW",
             IdentityNumbers = [
                 new () {  Text = "9998219" },
@@ -474,16 +473,63 @@ public class SerializerTests
                 new () {  Text = "9998215" },
             ]
         };
-       
+
         string Serialize<T>(T data) {
             var grammar = EdiGrammar.NewEdiFact();
-            
+
             using var writer = new StringWriter();
             new EdiSerializer().Serialize(writer, grammar, data);
             return writer.ToString();
         }
         var expected = $"UNA:+.? '{Environment.NewLine}GIN+AW+9998219+9998218+9998217+9998216+9998215'{Environment.NewLine}";
         var output = Serialize(source);
+        Assert.Equal(expected, output);
+    }
+
+    [Fact, Trait(Traits.Tag, "EDIFact")]
+    public void Serialize_Explicit_Indication_of_Nesting() {
+        var grammar = EdiGrammar.NewEdiFact();
+        grammar.ExplicitIndicationOfNesting = true;
+        var interchange = new EDIFACT_ExplicitNesting_issue227() {
+            Msg = new() {
+                Title = "Title",
+                L1s = [
+                    new() {
+                        Name = "Name 1",
+                        L2s = [
+                            new() {
+                                SubName = "Sub 1 1"
+                            },
+                            new() {
+                                SubName = "Sub 1 2"
+                            }
+                        ]
+                    },
+                    new() {
+                        Name = "Name 2",
+                        L2s = [
+                            new() {
+                                SubName = "Sub 2 1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var expected = new StringBuilder()
+    .AppendLine("UNA:+.? '")
+    .AppendLine("TIT+Title'")
+    .AppendLine("LE1:1+Name 1'")
+    .AppendLine("LE2:1:1+Sub 1 1'")
+    .AppendLine("LE2:1:2+Sub 1 2'")
+    .AppendLine("LE1:2+Name 2'")
+    .AppendLine("LE2:2:1+Sub 2 1'").ToString();
+        string output = null;
+        using (var writer = new StringWriter()) {
+            new EdiSerializer().Serialize(writer, grammar, interchange);
+            output = writer.ToString();
+        }
+
         Assert.Equal(expected, output);
     }
 }


### PR DESCRIPTION
This add support for printing explicit nesting levels as specified by the UN EDIFACT standard [here](https://unece.org/trade/uncefact/unedifact/part-4-chapter-22-syntax-rules#9.1:~:text=no%20nesting%20indication.-,9.1%20Explicit%20Indication%20of%20Nesting,-In%20the%20segment).

To enable this behaviour, a new `ExplicitIndicationOfNesting` property has been added to the `EdiGrammar`. Enabling it will make the serializer print nesting levels after the segment names.

I've also added a simple test to verify that it works properly.