### PR TITLE
Issue 281

### DIFF
--- a/src/indice.Edi/EdiSerializer.cs
+++ b/src/indice.Edi/EdiSerializer.cs
@@ -94,7 +94,7 @@ public class EdiSerializer
 
         var stack = new Stack<EdiStructure>();
         var structuralComparer = default(EdiPathComparer);
-        // If this is not a collection type asume this type is the interchange.
+        // If this is not a collection type assume this type is the interchange.
         if (!objectType.IsCollectionType()) {
 
             while (reader.Read()) {

--- a/src/indice.Edi/EdiSerializer.cs
+++ b/src/indice.Edi/EdiSerializer.cs
@@ -75,10 +75,10 @@ public class EdiSerializer
     #region Read internals
 
     internal virtual object DeserializeInternal(EdiReader reader, Type objectType) {
-        reader.SuppressBadEscapeSequenceErrors = SuppressBadEscapeSequenceErrors;
-
         if (reader == null)
             throw new ArgumentNullException(nameof(reader));
+
+        reader.SuppressBadEscapeSequenceErrors = SuppressBadEscapeSequenceErrors;
 
         var implicitSegments = new[] {
             reader.Grammar.FunctionalGroupHeaderTag,


### PR DESCRIPTION
This PR contains a small code fix where the reader object may be used before it's tested for NULL in DeserializeInternal. Also includes a small fix for misspelled code comments.